### PR TITLE
PLAN-822 add unassigned to surveys

### DIFF
--- a/app/controllers/surveys_controller.rb
+++ b/app/controllers/surveys_controller.rb
@@ -118,7 +118,7 @@ class SurveysController < ResourceController
       transition_decline_status
       declined_msg
       authenticate_msg
-      anonymous
+      unassigned
       welcome
       description
       mandatory_star

--- a/app/javascript/surveys/survey-page.vue
+++ b/app/javascript/surveys/survey-page.vue
@@ -95,7 +95,7 @@ export default {
   computed: {
     ...mapState(['redirMessage']),
     is_assigned() {
-      return this.preview || this.currentUser.assigned_surveys[this.surveyId]!=undefined;
+      return this.preview || this.currentUser.assigned_surveys[this.surveyId]!=undefined || this.survey.unassigned;
     },
     next_page() {
       return `/surveys/${this.surveyId}/page/${this.nextPageId}${this.preview === "preview" ? '/preview' : ''}`

--- a/app/javascript/surveys/survey-settings-tab.vue
+++ b/app/javascript/surveys/survey-settings-tab.vue
@@ -9,8 +9,8 @@
           Published&nbsp;<span v-if="survey.public">on {{new Date(survey.published_on).toLocaleString()}}</span>
         </b-col>
       </b-row>
-      <survey-setting disabled v-model="survey.anonymous" field="anonymous">
-        Anonymous
+      <survey-setting bool v-model="survey.unassigned" field="unassigned">
+        Allow this survey to be taken without assignment
       </survey-setting>
       <survey-setting bool v-model="survey.mandatory_star" field="mandatory_star">
         Show star for required questions <small>(What is your name? <span class="text-danger" title="required">*</span>&nbsp;)</small>

--- a/app/serializers/survey_serializer.rb
+++ b/app/serializers/survey_serializer.rb
@@ -5,7 +5,7 @@ class SurveySerializer
              :name, :welcome, :thank_you, :submit_string,
              :use_captcha, :public,
              :transition_accept_status, :transition_decline_status,
-             :declined_msg, :authenticate_msg, :anonymous,
+             :declined_msg, :authenticate_msg, :unassigned,
              :published_on, :description,
              :mandatory_star,
              :numbered_questions,

--- a/db/migrate/20230304203222_change_survey_column_name.rb
+++ b/db/migrate/20230304203222_change_survey_column_name.rb
@@ -1,0 +1,5 @@
+class ChangeSurveyColumnName < ActiveRecord::Migration[6.1]
+  def change
+    rename_column :surveys, :anonymous, :unassigned
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1939,7 +1939,7 @@ CREATE TABLE public.surveys (
     public boolean,
     declined_msg text,
     authenticate_msg text,
-    anonymous boolean DEFAULT false,
+    unassigned boolean DEFAULT false,
     published_on timestamp without time zone,
     published_by_id uuid,
     created_by_id uuid,
@@ -3429,6 +3429,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20220801195644'),
 ('20220818022629'),
 ('20220818200500'),
-('20220821001724');
+('20220821001724'),
+('20230304203222');
 
 


### PR DESCRIPTION
New survey setting: "Allow this survey to be taken without assignment"
<img width="754" alt="image" src="https://user-images.githubusercontent.com/634425/222928560-233c1274-c688-4543-809a-794d5d16986d.png">

When you check that and it's published, it lets you take the survey.
