### PR TITLE
Fix the startup for prod

### DIFF
--- a/script/planorama_start.sh
+++ b/script/planorama_start.sh
@@ -57,7 +57,7 @@ elif [[ $RAILS_ENV = "staging" ]]; then
 
   bin/rails db:seed
 else
-  until psql -Atx "postgresql://$POSTGRES_USER:$POSTGRES_PASSWORD@$DB_HOST/$DB_NAME" -c 'select current_date'; do
+  until psql -Atx "postgresql://$POSTGRES_USER:$POSTGRES_PASSWORD@$DB_HOST" -c 'select current_date'; do
     echo "waiting for postgres..."
     sleep 5
   done


### PR DESCRIPTION
This fixes issue #805 in that the check for PG to be up should not rely on the schema present
(next line creates the schema)