### PR TITLE
PLAN-841 fix remote validation

### DIFF
--- a/app/javascript/login/login_password_field.vue
+++ b/app/javascript/login/login_password_field.vue
@@ -78,7 +78,7 @@ export default {
       if (this.value.length < 1 || (!this.newPassword && !this.confirmation)) {
         return LOGIN_MISSING_PASSWORD;
       }
-      if (!this.passSecurityNeeds) {
+      if (!this.passSecurityNeeds && !this.confirmation) {
         return LOGIN_PASSWORD_UNSECURE;
       }
       if (this.confirmation) {
@@ -115,9 +115,12 @@ export default {
       if (this.value.length < minLength || !matching) {
         this.valid = false;
       }
+      if(this.confirmation && matching) {
+        this.valid = true;
+      }
 
       // only do the server side check if the JS checks have passed
-      if (this.valid) {
+      if (this.valid !== false && !this.confirmation) {
         // Enforce password security
         this.checkPasswordRules().then(
           () => {


### PR DESCRIPTION
- now actually sends the server call; it wasn't before because valid is very rarely true, just null.
- don't send backend check on confirmation
- mark validation as true on confirmation when matching (for green checkmark)
- fix confirmation validation message