### PR TITLE
PLAN-846 Format survey options for questions

### DIFF
--- a/app/javascript/surveys/options-question.vue
+++ b/app/javascript/surveys/options-question.vue
@@ -8,13 +8,14 @@
             <div class="float-left qhandle" v-if="isSelected"><b-icon-grip-vertical></b-icon-grip-vertical></div>
             <component :is="optionComponent" disabled class="ml-3" :i="i + 1">
               <plano-editor
-                v-if="isSelected"
+                v-if="isSelected && usePlanoEditor"
                 v-model="a.answer"
                 class="mt-n2 mb-2"
                 @change="patchAnswerText(a, $event)"
               >
               </plano-editor>
-              <span v-if="!isSelected">{{a.answer}}</span>
+              <b-form-input v-if="isSelected && !usePlanoEditor" v-model="a.answer" class="mt-n2 mb-2" @change="patchAnswerText(a, $event)"></b-form-input>
+              <span v-if="!isSelected" v-html="a.answer"></span>
             </component>
           </div>
           <div class="col-1 pb-2 text-center" v-if="isSelected">
@@ -97,6 +98,9 @@ export default {
     other: null,
   }),
   computed: {
+    usePlanoEditor() {
+      return this.singlechoice || this.multiplechoice;
+    },
     optionComponent() {
       switch(this.question.question_type) {
         case "singlechoice":

--- a/app/javascript/surveys/survey_question.vue
+++ b/app/javascript/surveys/survey_question.vue
@@ -95,7 +95,7 @@
               :value="choiceValue(choice)"
               :disabled="!answerable"
               @input="changeNextPage($event, choice)"
-            >{{choice.answer}}</b-form-radio>
+            ><span v-html="choice.answer"></span></b-form-radio>
             <b-form-radio
               class="mt-2"
               v-if="otherFromQuestion"
@@ -134,7 +134,7 @@
               :key="choice.id"
               :value="choiceValue(choice)"
               :disabled="!answerable"
-            >{{choice.answer}}</b-form-checkbox>
+            ><span v-html="choice.answer"></span></b-form-checkbox>
             <b-form-checkbox
               class="mt-2"
               v-if="otherFromQuestion"


### PR DESCRIPTION
We allowed you to add formatting, but we didn't ever render it; though i could SWEAR i implemented this at some point. Ah well, it's now implemented again!

Note: you can no longer use the html editor on dropdowns, as the browsers don't support styling that.