### PR TITLE
fixes the double redirect which causes render issue

### DIFF
--- a/app/javascript/login/login_screen.vue
+++ b/app/javascript/login/login_screen.vue
@@ -21,15 +21,20 @@ export default {
     personSessionMixin
   ],
   watch: {
-    loggedIn (newval, oldval) {
-      if (newval) {
-        if (this.hasPassword) {
-          this.$router.replace(this.redirect)
-        } else {
-          this.$router.push(`/login/setup?redirect=${this.redirect}`)
-        }
-      }
-    },
+    // NOTE:
+    // This causes a double redirect cause the router does the same thing
+    // and throughs an error which sometime causes the survey etc not to render
+    // AND the logic for this is handled in the router anyway
+    // Hence the commenting out
+    // loggedIn (newval, oldval) {
+    //   if (newval) {
+    //     if (this.hasPassword) {
+    //       this.$router.replace(this.redirect)
+    //     } else {
+    //       this.$router.push(`/login/setup?redirect=${this.redirect}`)
+    //     }
+    //   }
+    // },
     hasPassword(newVal, oldVal) {
       if (newVal && !oldVal) {
         this.$router.replace(this.redirect)


### PR DESCRIPTION
This is a prod issue. There is a double redirect that causes the router to error when redirecting to survey - causing participant confusion.
This is because the logic was in two places - I have commented out the login in the login screen so that the router handles it.