### PR TITLE
Plan 873 landing page text

### DIFF
--- a/app/controllers/page_contents_controller.rb
+++ b/app/controllers/page_contents_controller.rb
@@ -1,0 +1,11 @@
+class PageContentsController < ResourceController
+  SERIALIZER_CLASS = 'PageContentSerializer'.freeze
+  POLICY_CLASS = 'PageContentPolicy'.freeze
+  POLICY_SCOPE_CLASS = 'PageContentPolicy::Scope'.freeze
+
+  skip_before_action :authenticate_person!, only: [:index, :show]
+
+  def paginate
+    false
+  end
+end

--- a/app/javascript/administration/admin_component.vue
+++ b/app/javascript/administration/admin_component.vue
@@ -59,6 +59,9 @@
           ref="agreements-manager"
         ></agreement-manager>
       </admin-accordion>
+      <admin-accordion id="page-content-accordion" title="Page Content Editor">
+        <page-content-editor></page-content-editor>
+      </admin-accordion>
     </div>
   </div>
 </template>
@@ -73,6 +76,7 @@ import SheetImporterVue from '../components/sheet_importer_vue.vue';
 import AgreementManager from "@/agreements/agreement_manager.vue";
 import ScheduleSettings from "@/schedule/schedule_settings.vue";
 import IntegrationSettings from "@/integrations/integration_settings.vue"
+import PageContentEditor from '@/page-content/page_content_editor.vue';
 
 export default {
   components: {
@@ -85,6 +89,7 @@ export default {
     ConfigurationsManager,
     ScheduleSettings,
     IntegrationSettings,
+    PageContentEditor,
   },
   name: 'AdminComponent',
   data: () => ({

--- a/app/javascript/administration/playground_component.vue
+++ b/app/javascript/administration/playground_component.vue
@@ -1,0 +1,19 @@
+<template>
+<div>
+  <p>This is a playground for new features ...</p>
+  <page-content-editor></page-content-editor>
+</div>
+</template>
+
+<script>
+import PageContentEditor from "@/page-content/page_content_editor.vue"
+
+export default {
+  name: "PlayGroundComponent",
+  components: {
+    PageContentEditor
+  },
+}
+</script>
+
+<style></style>

--- a/app/javascript/administration/playground_component.vue
+++ b/app/javascript/administration/playground_component.vue
@@ -1,6 +1,7 @@
 <template>
-<div>
-  <p>This is a playground for new features ...</p>
+<div class="container-fluid scrollable">
+  <h1>Preview features</h1>
+  <h2>Page content editor (for the dashboard)</h2>
   <page-content-editor></page-content-editor>
 </div>
 </template>

--- a/app/javascript/app.router.js
+++ b/app/javascript/app.router.js
@@ -18,6 +18,8 @@ const loginRoutes = [
 // admin
 import AdminComponent from './administration/admin_component.vue';
 
+import PlayGroundComponent from './administration/playground_component.vue';
+
 // people
 import PeopleScreen from './people/people-screen.vue';
 import PeopleList from './people/people_list.vue';
@@ -131,11 +133,19 @@ export const router = new VueRouter({
     //   }
     // },
     {
+      path: '/playground',
+      component: PlayGroundComponent,
+      meta: {
+        requiresAuth: true,
+        requiresAdmin : true
+      }
+    },
+    {
       path: '/admin',
       component: AdminComponent,
       meta: {
         requiresAuth: true,
-        requiresAdmin : true
+        requiresAdmin: true
       }
     },
     {

--- a/app/javascript/components/plano_editor.vue
+++ b/app/javascript/components/plano_editor.vue
@@ -86,6 +86,7 @@ export default {
 
       local_config.enterMode = 2 // This is CKEDITOR.ENTER_BR
       local_config.toolbar = toolbar
+      local_config.contentsCss = "custom.scss"
 
       if (this.height) local_config.height = this.height
 

--- a/app/javascript/constants/strings.js
+++ b/app/javascript/constants/strings.js
@@ -268,6 +268,9 @@ module.exports = {
         virtual: "Virtually",
     },
 
+    PAGE_CONTENT_SAVE_SUCCESS: "Page content saved successfully", 
+    PAGE_CONTENT_SAVE_ERROR: "Page content save failed",
+
     SURVEY_REDIRECT: "Unfortunately due to the browser refreshing we have lost any answers you filled in. Please fill the survey out again.",
     SURVEY_PUBLIC_NO_EDIT: "You cannot edit a published survey. Close the survey to enable editing.",
     SURVEY_PUBLIC_NO_DELETE: "You cannot delete a published survey. Close the survey to enable deletion.",

--- a/app/javascript/dashboard/dashboard.vue
+++ b/app/javascript/dashboard/dashboard.vue
@@ -6,7 +6,7 @@
         You'll be using this site between now and the convention to view and manage your profile, interests and schedule.
       </p>
       <div v-if="!draftSchedule  && doneLoading">
-        <page-content-display name="dashboard-intro">
+        <page-content-display name="dashboard-default">
           <p>
             To get started, click on <a href="/#/profile">Profile</a>.
           </p>
@@ -97,6 +97,7 @@
         </page-content-display>
       </div>
       <div v-if="displayDraftSchedule">
+        <page-content-display name="dashboard-schdule"></page-content-display>
         <person-schedule-display :sessions="sessions" title="Your Draft Schedule">
           <template #message>
             <router-link to="/profile/draft-schedule">Approve your draft schedule<br />or provide change requests.</router-link>
@@ -104,6 +105,7 @@
         </person-schedule-display>
       </div>
       <div v-if="firmSchedule">
+        <page-content-display name="dashboard-schedule"></page-content-display>
         <person-schedule-display :sessions="sessions" title="Your Schedule">
           <template #message>
             <router-link to="/profile/schedule">Approve your schedule<br />or provide change requests.</router-link>

--- a/app/javascript/dashboard/dashboard.vue
+++ b/app/javascript/dashboard/dashboard.vue
@@ -6,93 +6,95 @@
         You'll be using this site between now and the convention to view and manage your profile, interests and schedule.
       </p>
       <div v-if="!draftSchedule  && doneLoading">
-        <p>
-          To get started, click on <a href="/#/profile">Profile</a>.
-        </p>
-        <p>
-          At this point there are 5 tabs in the profile. You will need to visit all of them.
-        </p>
-        <ul>
-          <li>
-            <b>General Tab</b>
-            <ul>
-              <li>
-                Update your name(s), pronouns, email address, bio, and social media as needed
-              </li>
-              <li v-if="eventVirtual">
-                If you’re not going to be attending the convention in-person, please let us know the timezone that you will be in when you attend virtually.
-              </li>
-            </ul>
-          </li>
-          <li>
-            <b>Demographics &amp; Community</b>
-            <ul>
-              <li>Fill in your information as needed.</li>
-            </ul>
-          </li>
-          <li>
-            <b>Availability</b>
-            <ul>
-              <li>
-                Fill in the maximum number of program items you would like to be on.
-              </li>
-              <li>
-                Select blocks of time you will be available during the convention on the availability calendar.
-              </li>
-              <li>
-                Select any of the specific cornerstone items you do not want to be scheduled against.
-              </li>
-              <li>
-                Let us know any other scheduling constraints you have in the free text box.
-              </li>
-            </ul>
-          </li>
-          <li>
-            <b>Session Selection</b>
-            <ul>
-              <li>
-                Use this tab to tell us what program items you are interested in.
-              </li>
-              <li>
-                You can filter the options for one area, look through all options (over 600!) or search based on text in the title and description. (Note: You need to click the search button - hitting enter does not work.)
-              </li>
-              <li>
-                Select sessions by using the slider to the right of the description. Your selections will save automatically.
-              </li>
-              <li v-if="eventVirtual">
-                While some items are marked or otherwise described as Virtual, many we’re not sure if they will be taking place in-person or online, so everyone should feel free to sign up for items not marked either way.
-              </li>
-            </ul>
-          </li>
-          <li>
-            <b>Session Rankings</b>
-            <p>
-              The list of sessions you selected will display here. For each session:
+        <page-content-display name="dashboard-intro">
+          <p>
+            To get started, click on <a href="/#/profile">Profile</a>.
+          </p>
+          <p>
+            At this point there are 5 tabs in the profile. You will need to visit all of them.
+          </p>
+          <ul>
+            <li>
+              <b>General Tab</b>
               <ul>
                 <li>
-                  Add a ranking 1-3. The ranking system is explained on the tab. You may leave panels unranked.
+                  Update your name(s), pronouns, email address, bio, and social media as needed
                 </li>
-                <li>
-                  Indicate moderation preference for the individual items.
-                </li>
-                <li>
-                  Use the text box to tell us why you are a good choice for this panel and what you would contribute.
+                <li v-if="eventVirtual">
+                  If you’re not going to be attending the convention in-person, please let us know the timezone that you will be in when you attend virtually.
                 </li>
               </ul>
-            </p>
-            <p>
-              Please follow the additional prompt, if present.
+            </li>
+            <li>
+              <b>Demographics &amp; Community</b>
+              <ul>
+                <li>Fill in your information as needed.</li>
+              </ul>
+            </li>
+            <li>
+              <b>Availability</b>
               <ul>
                 <li>
-                  A sentence or two is often sufficient; essays are not required.
+                  Fill in the maximum number of program items you would like to be on.
                 </li>
                 <li>
-                  We have about 1000 potential panelists and about two dozen staffers engaged in panelist assignments; this step helps us learn more about you in the context of a particular session.
+                  Select blocks of time you will be available during the convention on the availability calendar.
+                </li>
+                <li>
+                  Select any of the specific cornerstone items you do not want to be scheduled against.
+                </li>
+                <li>
+                  Let us know any other scheduling constraints you have in the free text box.
                 </li>
               </ul>
-            </p>
-          </li>
-        </ul>
+            </li>
+            <li>
+              <b>Session Selection</b>
+              <ul>
+                <li>
+                  Use this tab to tell us what program items you are interested in.
+                </li>
+                <li>
+                  You can filter the options for one area, look through all options (over 600!) or search based on text in the title and description. (Note: You need to click the search button - hitting enter does not work.)
+                </li>
+                <li>
+                  Select sessions by using the slider to the right of the description. Your selections will save automatically.
+                </li>
+                <li v-if="eventVirtual">
+                  While some items are marked or otherwise described as Virtual, many we’re not sure if they will be taking place in-person or online, so everyone should feel free to sign up for items not marked either way.
+                </li>
+              </ul>
+            </li>
+            <li>
+              <b>Session Rankings</b>
+              <p>
+                The list of sessions you selected will display here. For each session:
+                <ul>
+                  <li>
+                    Add a ranking 1-3. The ranking system is explained on the tab. You may leave panels unranked.
+                  </li>
+                  <li>
+                    Indicate moderation preference for the individual items.
+                  </li>
+                  <li>
+                    Use the text box to tell us why you are a good choice for this panel and what you would contribute.
+                  </li>
+                </ul>
+              </p>
+              <p>
+                Please follow the additional prompt, if present.
+                <ul>
+                  <li>
+                    A sentence or two is often sufficient; essays are not required.
+                  </li>
+                  <li>
+                    We have about 1000 potential panelists and about two dozen staffers engaged in panelist assignments; this step helps us learn more about you in the context of a particular session.
+                  </li>
+                </ul>
+              </p>
+            </li>
+          </ul>
+        </page-content-display>
       </div>
       <div v-if="displayDraftSchedule">
         <person-schedule-display :sessions="sessions" title="Your Draft Schedule">
@@ -118,12 +120,14 @@ import { mapActions } from 'vuex';
 import { FETCH_WORKFLOWS, scheduleWorkflowMixin } from '@/store/schedule_workflow';
 import PersonScheduleDisplay from '@/profile/person_schedule_display.vue';
 import { eventVirtualMixin } from '@/shared/event-virtual.mixin';
+import PageContentDisplay from '@/page-content/page_content_display.vue'
 
 export default {
   name: "Dashboard",
   mixins: [personSessionMixin, toastMixin, scheduleWorkflowMixin, eventVirtualMixin],
   components: {
-    PersonScheduleDisplay
+    PersonScheduleDisplay,
+    PageContentDisplay
   },
   methods: {
     ...mapActions({

--- a/app/javascript/page-content/page_content.mixin.js
+++ b/app/javascript/page-content/page_content.mixin.js
@@ -1,0 +1,26 @@
+import { mapGetters, mapState, mapActions } from 'vuex';
+import toastMixin from '../shared/toast-mixin';
+import { NEW_PAGE_CONTENT } from '@/store/page_content.store';
+import { PAGE_CONTENT_SAVE_SUCCESS, PAGE_CONTENT_SAVE_ERROR } from '../constants/strings'
+import modelUtilsMixin from '../store/model_utils.mixin'
+
+export const pageContentMixin = {
+  mixins: [toastMixin, modelUtilsMixin],
+  methods: {
+    ...mapActions({
+      new_page_content: NEW_PAGE_CONTENT
+    }),
+    savePageContent(newPageContent, success_text = PAGE_CONTENT_SAVE_SUCCESS, error_text = PAGE_CONTENT_SAVE_ERROR) {
+      if (newPageContent.id) {
+        return this.save_model('page_content', newPageContent)
+      } else {
+        return this.toastPromise(
+          this.new_page_content(newPageContent),
+          success_text, error_text
+        )
+      }
+    },
+  }
+}
+
+export default pageContentMixin;

--- a/app/javascript/page-content/page_content_display.vue
+++ b/app/javascript/page-content/page_content_display.vue
@@ -1,0 +1,47 @@
+<template>
+  <div>
+    <div v-if="collection.length > 0">
+      <div v-for="content in collection" :key="content.id" v-html="content.html"></div>
+    </div>
+    <div v-else>
+      <slot></slot>
+    </div>
+  </div>
+</template>
+
+<!-- 
+  Given a name get that content from the backend and put in on the page
+
+  TODO: a page content editor (name, html), as a seperate component
+ -->
+<script>
+import { modelMixinNoProp } from '@/mixins'
+import pageContentMixin from '@/page-content/page_content.mixin'
+
+export default {
+  name: "PageContentDisplay",
+  props: {
+    name: {
+      type: String,
+      default: null
+    },
+  },
+  data: () => ({
+    model: 'page_content'
+  }),
+  mixins: [
+    modelMixinNoProp,
+    pageContentMixin
+  ],
+  methods: {
+  },
+  mounted() {
+    // get the content from the backend
+    // backend restricts content to 1 for any given name anyway
+    this.fetch({filter: `{"op":"all","queries":[["name", "=", "${this.name}"]]}`});
+  }
+}
+</script>
+
+<style>
+</style>

--- a/app/javascript/page-content/page_content_editor.vue
+++ b/app/javascript/page-content/page_content_editor.vue
@@ -1,6 +1,10 @@
 <template>
-<div>
-  <b-form-select v-model="name" :options="options"></b-form-select>
+<div class="mr-3">
+  <b-form-select v-model="name" :options="options" class="w-50 mb-2">
+    <template #first>
+      <option :value="null">Select a content area to edit</option>
+    </template>
+  </b-form-select>
   <plano-editor
     v-model="content.html"
     type='classic'
@@ -28,11 +32,8 @@ export default {
       content: this.starter_content(),
       name: null,
       options: [
-        // NOTE: put in as many options as we want text for
-        // dashboard-intro is the introduction test for the dashboard (sans any publish)
-        { value: 'dashboard-intro', text: 'dashboard-intro' },
-        // stuff is just a dummy example
-        { value: 'dashboard-stuff', text: 'dashboard-stuff' }
+        { value: 'dashboard-default', text: 'Dashboard - Default' },
+        { value: 'dashboard-schedule', text: 'Dashboard - After Draft Publish' }
       ]
     }
   },

--- a/app/javascript/page-content/page_content_editor.vue
+++ b/app/javascript/page-content/page_content_editor.vue
@@ -1,0 +1,84 @@
+<template>
+<div>
+  <b-form-select v-model="name" :options="options"></b-form-select>
+  <plano-editor
+    v-model="content.html"
+    type='classic'
+  ></plano-editor>
+  <!-- TODO - do we want a delete? -->
+  <b-button variant="primary" @click="saveContent">Save</b-button>
+
+</div>
+</template>
+
+<script>
+import { modelMixinNoProp } from '@/mixins'
+import pageContentMixin from '@/page-content/page_content.mixin'
+import PlanoEditor from '@/components/plano_editor';
+
+export default {
+  name: "PageContentEditor",
+  components: {
+    PlanoEditor,
+  },
+  data() {
+    return {
+      model: 'page_content',
+      loading: true,
+      content: this.starter_content(),
+      name: null,
+      options: [
+        // NOTE: put in as many options as we want text for
+        // dashboard-intro is the introduction test for the dashboard (sans any publish)
+        { value: 'dashboard-intro', text: 'dashboard-intro' },
+        // stuff is just a dummy example
+        { value: 'dashboard-stuff', text: 'dashboard-stuff' }
+      ]
+    }
+  },
+  mixins: [
+    modelMixinNoProp,
+    pageContentMixin
+  ],
+  watch: {
+    name(newVal, oldVal) {
+      if (newVal) {
+        // fetch the content
+        this.fetch_content()
+      }
+    }
+  },
+  methods: {
+    starter_content() {
+      return {
+        id: null,
+        name: '',
+        html: ''
+      }
+    },
+    saveContent() {
+      let res = this.savePageContent(this.content);
+      res.then(
+        (obj) => {
+          this.content = obj
+        }
+      )
+    },
+    fetch_content() {
+      if (this.name) {
+        this.clear()
+        this.fetch({ filter: `{"op":"all","queries":[["name", "=", "${this.name}"]]}` }).then(
+          (col) => {
+            if (this.collection.length > 0) {
+              this.content = this.collection[0]
+            } else {
+              this.content = this.starter_content()
+              this.content.name = this.name
+            }
+          }
+        )
+      }
+    },
+  }
+}
+</script>

--- a/app/javascript/store/model.store.js
+++ b/app/javascript/store/model.store.js
@@ -33,6 +33,9 @@ import { roomStore, roomEndpoints } from './room.store';
 import { roomSetStore, roomSetEndpoints} from "@/store/room_set.store";
 import { venueStore, venueEndpoints} from "@/store/venue.store";
 
+// Page content (html)
+import { pageContentStore, pageContentEndpoints } from "@/store/page_content.store";
+
 // mailings
 import { mailingStore, mailingEndpoints } from './mailing.store';
 
@@ -96,6 +99,7 @@ const endpoints = {
   ...roomEndpoints,
   ...roomSetEndpoints,
   ...venueEndpoints,
+  ...pageContentEndpoints,
   ...surveyEndpoints,
   ...mailingEndpoints,
   ...sessionEndpoints,
@@ -139,6 +143,7 @@ export const store = new Vuex.Store({
       ...roomStore.selected,
       ...roomSetStore.selected,
       ...venueStore.selected,
+      ...pageContentStore.selected,
       ...surveyStore.selected,
       ...mailingStore.selected,
       ...sessionStore.selected,
@@ -188,6 +193,7 @@ export const store = new Vuex.Store({
     ...roomSetStore.getters,
     ...venueStore.getters,
     ...surveyStore.getters,
+    ...pageContentStore.getters,
     ...personSessionStore.getters,
     ...mailingStore.getters,
     ...sessionStore.getters,
@@ -379,6 +385,7 @@ export const store = new Vuex.Store({
     ...agreementStore.actions,
     ...roomStore.actions,
     ...roomSetStore.actions,
+    ...pageContentStore.actions,
     ...venueStore.actions,
     ...mailingStore.actions,
     ...settingsStore.actions,

--- a/app/javascript/store/page_content.store.js
+++ b/app/javascript/store/page_content.store.js
@@ -1,0 +1,22 @@
+import { NEW } from './model.store';
+
+export const NEW_PAGE_CONTENT = 'NEW PAGE CONTENT';
+
+export const pageContentModel = 'page_content';
+
+export const pageContentEndpoints = {
+  [pageContentModel]: 'page_content'
+}
+
+export const pageContentStore = {
+  actions: {
+    [NEW_PAGE_CONTENT] ({dispatch}, attributes) {
+      return dispatch(NEW, { model: pageContentModel, selected: false, ...attributes})
+    },
+  },
+  selected: {
+    [pageContentModel]: undefined
+  },
+  getters: {
+  }
+}

--- a/app/models/page_content.rb
+++ b/app/models/page_content.rb
@@ -1,0 +1,2 @@
+class PageContent < ApplicationRecord
+end

--- a/app/policies/page_content_policy.rb
+++ b/app/policies/page_content_policy.rb
@@ -1,0 +1,7 @@
+class PageContentPolicy < PlannerPolicy
+  class Scope < PlannerPolicy::Scope
+    def resolve
+      scope.all
+    end
+  end
+end

--- a/app/serializers/page_content_serializer.rb
+++ b/app/serializers/page_content_serializer.rb
@@ -1,0 +1,6 @@
+class PageContentSerializer
+  include JSONAPI::Serializer
+
+  attributes :id, :lock_version, :created_at, :updated_at,
+             :html, :name
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -190,6 +190,7 @@ Rails.application.routes.draw do
   resources :tag_contexts, path: 'tag_context'
   resources :configurations, path: 'configuration'
   resources :parameter_names, path: 'parameter_name'
+  resources :page_contents, path: 'page_content'
 
   get 'person_schedule_approval/fetch/:person_id/:workflow_id', to: 'person_schedule_approvals#fetch'
   post 'person_schedule_approval/approve/:person_id/:workflow_id', to: 'person_schedule_approvals#approve'

--- a/db/migrate/20230924145027_create_page_contents.rb
+++ b/db/migrate/20230924145027_create_page_contents.rb
@@ -1,0 +1,11 @@
+class CreatePageContents < ActiveRecord::Migration[6.1]
+  def change
+    create_table :page_contents, id: :uuid do |t|
+      t.text :html, null: false
+      t.string :name, null: false, index: { unique: true, name: 'unique_page_content' }
+
+      t.integer :lock_version
+      t.timestamps
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1074,6 +1074,24 @@ CREATE TABLE public.model_permissions (
 
 
 --
+-- Name: oauth_identities; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.oauth_identities (
+    id uuid DEFAULT public.gen_random_uuid() NOT NULL,
+    provider character varying,
+    person_id uuid,
+    reg_id character varying,
+    reg_number character varying,
+    email character varying,
+    raw_info jsonb DEFAULT '{}'::jsonb NOT NULL,
+    lock_version integer,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
 -- Name: old_passwords; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -1104,6 +1122,20 @@ CREATE SEQUENCE public.old_passwords_id_seq
 --
 
 ALTER SEQUENCE public.old_passwords_id_seq OWNED BY public.old_passwords.id;
+
+
+--
+-- Name: page_contents; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.page_contents (
+    id uuid DEFAULT public.gen_random_uuid() NOT NULL,
+    html text NOT NULL,
+    name character varying NOT NULL,
+    lock_version integer,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
 
 
 --
@@ -2358,11 +2390,27 @@ ALTER TABLE ONLY public.model_permissions
 
 
 --
+-- Name: oauth_identities oauth_identities_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.oauth_identities
+    ADD CONSTRAINT oauth_identities_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: old_passwords old_passwords_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.old_passwords
     ADD CONSTRAINT old_passwords_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: page_contents page_contents_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.page_contents
+    ADD CONSTRAINT page_contents_pkey PRIMARY KEY (id);
 
 
 --
@@ -3274,6 +3322,13 @@ CREATE INDEX taggings_taggable_context_idx ON public.taggings USING btree (tagga
 
 
 --
+-- Name: unique_page_content; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX unique_page_content ON public.page_contents USING btree (name);
+
+
+--
 -- Name: categorizations fk_categorization_category; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -3500,6 +3555,8 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20220818200500'),
 ('20220821001724'),
 ('20230304203222'),
-('20230411123748');
+('20230411123748'),
+('20230602193356'),
+('20230924145027');
 
 

--- a/lib/tasks/rbac.rake
+++ b/lib/tasks/rbac.rake
@@ -12,17 +12,17 @@ namespace :rbac do
       con_roles: ['participant'],
       name: 'Participant_Roles_Default',
       sensitive_access: false
-    ).delete_all
+    ).destroy_all
     role = ApplicationRole.where(
       con_roles: ['staff'],
       name: 'Staff_Roles_Default',
       sensitive_access: false
-    ).delete_all
+    ).destroy_all
     role = ApplicationRole.where(
       con_roles: ['admin'],
       name: 'Admin_Roles_Default',
       sensitive_access: true
-    ).delete_all
+    ).destroy_all
   end
 
   def create_participant_roles
@@ -286,6 +286,13 @@ namespace :rbac do
       },
       "integration": {
           "publish": false
+      },
+      "page_content": {
+        "create": false,
+        "destroy": false,
+        "index": true,
+        "show": true,
+        "update": false
       }
     })
   end
@@ -610,6 +617,13 @@ namespace :rbac do
       },
       "integration": {
           "publish": false
+      },
+      "page_content": {
+        "create": false,
+        "destroy": false,
+        "index": true,
+        "show": true,
+        "update": false
       }
     })
   end
@@ -934,6 +948,13 @@ namespace :rbac do
       },
       "integration": {
           "publish": true
+      },
+      "page_content": {
+        "create": true,
+        "destroy": true,
+        "index": true,
+        "show": true,
+        "update": true
       }
     })
   end

--- a/spec/factories/page_contents.rb
+++ b/spec/factories/page_contents.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :page_content do
+    sequence(:name) { |n| "page #{n}" }
+    html { "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>" }
+  end
+end

--- a/spec/requests/page_contents_spec.rb
+++ b/spec/requests/page_contents_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+#
+# Test the person end points ...
+#
+RSpec.describe 'Page Contents', type: :request do
+  before {
+    create_list(:page_content, 10)
+    sign_in_person
+  }
+
+  after {
+    sign_out_person
+  }
+
+  describe 'Page Contents' do
+    it 'Gets list of page content' do
+      # create_list(:page_content, 10)
+      get "/page_content"
+
+      # puts "******* #{json}"
+      expect(response).to have_http_status(200)
+      expect(json).not_to be_empty
+    end
+  end
+
+  # We want to get an individual page by name
+  # a filter would do but ...
+  describe 'Get page 1' do
+    it 'Gets list of page content' do
+      # create_list(:page_content, 10)
+      # get "/page_content"
+      params = URI.encode 'filter={"op":"all","queries":[["name", "=", "page 1"]]}'
+
+      get "/page_content?#{params}"
+      # puts "******* #{json}"
+      expect(response).to have_http_status(200)
+      expect(json).not_to be_empty
+    end
+  end
+end

--- a/test/models/page_content_test.rb
+++ b/test/models/page_content_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class PageContentTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Here is the code to support page text from the db

It will take content from the slot if the content corresponding to name does not exist in the DB

```
<page-content-display name="dashboard-intro">
some other stuff
</page-content-display>
```

There is a test editor in the /#/playground that can be used to edit/create the text using a CKeditor. There is a drop down, just add the names of the text areas that you want to the drop down and the editor to create. We can use this for any customizable area ...