### PR TITLE
Plan 874 text fixes

### DIFF
--- a/app/javascript/login/iea-modal.vue
+++ b/app/javascript/login/iea-modal.vue
@@ -11,14 +11,14 @@
       </template>
       <div class="terms">
         <!--TODO use the database value -->
-        <p>This system contains Personal Data for Chicon staff members, program participants, and prospective program participants. This includes names, email addresses, and telephone numbers as well as survey responses, proposed and scheduled program sessions, copies of correspondence with program participants, and other information.</p>
+        <p>This system contains Personal Data for staff members, program participants, and prospective program participants. This includes names, email addresses, and telephone numbers as well as survey responses, proposed and scheduled program sessions, copies of correspondence with program participants, and other information.</p>
         <p>Further, some information is considered Sensitive Personal Data under the European Union General Data Protection Regulation (GDPR) including demographic information for some program participants and prospective program participants.</p>
         <p>These terms and conditions documented below cover all information stored in the system.</p>
         <p>You must agree to the following statements in order to have access to this system:</p>
         <ul>
           <li>I understand my account is for my exclusive use only.</li>
-          <li>I will ONLY use the information stored in the system for the purposes of Chicon convention planning, including program development.</li>
-          <li>I will follow the Program Division Data Protection Policies, and the Chicon Privacy Policy.</li>
+          <li>I will ONLY use the information stored in the system for the purposes of convention planning, including program development.</li>
+          <li>I will follow the Program Division Data Protection Policies, and the conventions Privacy Policy.</li>
           <li>I acknowledge that my activities and usage of this system are logged and may be reviewed by an administrator if needed.</li>
           <li>I understand that If my account is terminated that while my user record will be deleted in the same manner as a program participant’s record would be deleted, some of my Personally Identifiable Information (i.e., name, email address, account name) may be retained in certain records such as program session notes and application log files.</li>
         </ul>
@@ -29,7 +29,7 @@
           <li>If someone else needs access to the system, I will direct them to their division head to obtain their own account.</li>
           <li>If I ever discover that my login information has been captured or compromised in any way, I will immediately notify the head of Program, the chair, or any other staff with administrator privileges on this system by any means available or necessary so my account can be blocked from use by others.</li>
           <li>If my password was compromised, I will update my password immediately.</li>
-          <li>If I have access to Chicon Sensitive Personal Data, I will only share that information with other staff members who also have that access.</li>
+          <li>If I have access to the Conventions Sensitive Personal Data, I will only share that information with other staff members who also have that access.</li>
           <li>I will not view or use an attendee's information unless there is a legitimate convention need to do so. </li>
           <li>I will not browse through data for entertainment/amusement.</li>
           <li>I will not update my personal address book or contacts list with the information from the system without prior explicit permission given by the individual(s) I am adding/updating.</li>

--- a/app/javascript/profile/availability_and_interests.vue
+++ b/app/javascript/profile/availability_and_interests.vue
@@ -12,9 +12,9 @@
           </session-limit-editor>
         <p>
           Under each day, highlight (click and drag) the times of day that you are available for programming in the calendar view below.
-          You can create multiple blocks of time per day. <span v-if="eventVirtual" >The in-person convention time is currently displayed,
-          and is Central Daylight Time (UTC-5). If you will be attending virtually,
-          and want to enter your availability in that time zone, select that option from below the calendar.
+          You can create multiple blocks of time per day. <span v-if="eventVirtual" >The in-person convention time is currently displayed.
+          If you will be attending virtually, and want to enter your availability in that time zone,
+          select that option from below the calendar.
           </span>
           <span v-if="!eventVirtual">The time is displayed in the convention time zone, which is currently {{timezone}}.</span>
         </p>

--- a/app/javascript/shared/toast-mixin.js
+++ b/app/javascript/shared/toast-mixin.js
@@ -1,7 +1,9 @@
 import { SUCCESS_TOAST_TITLE, ERROR_TOAST_TITLE, nLines, ERROR_GENERIC_RECOVERABLE, ERROR_GENERIC_UNRECOVERABLE } from "@/constants/strings"
-import { errorEmail } from "@/constants/config";
+// import { errorEmail } from "@/constants/config";
+import settingsMixin from "@/store/settings.mixin";
 
 export const toastMixin = {
+  mixins: [settingsMixin],
   methods: {
     success_toast(text) {
       if (typeof text === "function") {
@@ -37,10 +39,11 @@ export const toastMixin = {
       }
     },
     toastPromise(promise, success_text, error_text) {
+      let event_email = this.configByName('event_email');
       return new Promise((res, rej) => {
         promise.then((item) => {
           if(item.status && item.status >= 400) {
-            this.error_toast(getErrorText(item, error_text))
+            this.error_toast(getErrorText(event_email, item, error_text))
             rej(item)
           } else {
             this.success_toast(success_text);
@@ -49,7 +52,7 @@ export const toastMixin = {
         })
         .catch((error) => {
           console.error(error, error.response)
-          this.error_toast(getErrorText(error.response, error_text))
+          this.error_toast(getErrorText(event_email, error.response, error_text))
           rej(error);
         })
       });
@@ -57,7 +60,8 @@ export const toastMixin = {
   }
 }
 
-function getErrorText(errorResp, errorText) {
+// FIX
+function getErrorText(errorEmail, errorResp, errorText) {
   if (errorResp?.status === 422) {
     // if i have data, i can provide specific messages with, use that
     try {


### PR DESCRIPTION
Remove the central timezone from the availability instructions (so it is not Chicon specific)

I also removed some other Chicon references and use the event email in the toast error display (instead of chicon's one)