### PR TITLE
PLAN-881 fix the serialization of the session format

### DIFF
--- a/app/serializers/session_serializer.rb
+++ b/app/serializers/session_serializer.rb
@@ -68,8 +68,8 @@ class SessionSerializer
 
   has_many :participant_assignments, lazy_load_data: true, serializer: SessionAssignmentSerializer
 
-  has_one :format, lazy_load_data: true,
-          if: Proc.new { |record| record.format },
+  has_one :format,
+          if: Proc.new { |record| record.format_id },
           links: {
             self: -> (object, params) {
               "#{params[:domain]}/session/#{object.id}"


### PR DESCRIPTION
Fixes the missing session format in the serialized objects and hence the display in the profile