### PR TITLE
Issue when an item does not have a format,

### DIFF
--- a/app/views/xml_templates/schedule.nokogiri
+++ b/app/views/xml_templates/schedule.nokogiri
@@ -36,7 +36,9 @@ xml.schedule {
       xml.roomareasformat{
         session.environment == 'virtual' ? xml.virtual(session.room.name) : xml.room(session.room.name)
         xml.areas(session.area_list.join(", "))
-        !session.area_list.include?(session.format.name) ? xml.format(session.format.name) : ""
+        if session.format
+          !session.area_list.include?(session.format.name) ? xml.format(session.format.name) : ""
+        end
         session.streamed ? xml.streamed("- Livestream") : ""
         session.recorded ? xml.recorded("- Recorded") : ""
       }


### PR DESCRIPTION
indesign xml generation breaks.
Put in guard for this case

Not urgent - this is a fix to put in some future release