### PR TITLE
Adding Task support and instructions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,6 +122,7 @@ GEM
     et-orbi (1.2.7)
       tzinfo
     eventmachine (1.2.7)
+    eventmachine (1.2.7-x64-mingw32)
     factory_bot (6.2.1)
       activesupport (>= 5.0.0)
     factory_bot_rails (6.2.0)
@@ -136,6 +137,7 @@ GEM
     fast_excel (0.4.1)
       ffi (> 1.9, < 2)
     ffi (1.15.5)
+    ffi (1.15.5-x64-mingw32)
     formatador (1.1.0)
     fugit (1.8.1)
       et-orbi (~> 1, >= 1.2.7)
@@ -228,6 +230,8 @@ GEM
     nokogiri (1.15.4)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
+    nokogiri (1.15.4-x64-mingw32)
+      racc (~> 1.4)
     nokogiri (1.15.4-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.15.4-x86_64-linux)
@@ -261,6 +265,7 @@ GEM
       ast (~> 2.4.1)
       racc
     pg (1.5.4)
+    pg (1.5.4-x64-mingw32)
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -381,6 +386,8 @@ GEM
       sassc-rails (~> 2.1, >= 2.1.1)
     sassc (2.4.0)
       ffi (~> 1.9)
+    sassc (2.4.0-x64-mingw32)
+      ffi (~> 1.9)
     sassc-rails (2.1.2)
       railties (>= 4.0.0)
       sassc (>= 2.0)
@@ -427,9 +434,12 @@ GEM
       simpleidn (~> 0.2.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    tzinfo-data (1.2023.3)
+      tzinfo (>= 1.0.0)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.8.2)
+    unf_ext (0.0.8.2-x64-mingw32)
     unicode-display_width (2.4.2)
     version_gem (1.1.3)
     warden (1.2.9)
@@ -462,6 +472,7 @@ GEM
 
 PLATFORMS
   ruby
+  x64-mingw32
   x86_64-darwin-20
   x86_64-linux
   x86_64-linux-musl

--- a/README.md
+++ b/README.md
@@ -76,6 +76,15 @@ NOTE: the docker image will use the files from the project directory.
 So editing those files will affect what is running in docker (and most
 changes can be seen by refreshing the page you are working on)
 
+### Using Task
+
+If you'd rather not type out docker commands, you can use [Task](https://taskfile.dev/) instead. 
+First [install](https://taskfile.dev/installation/) it on your machine, then run `task -l` from the repo root 
+to see all commands available. There are commands for starting and stopping services, as well as for doing various
+steps in the ruby dev process like `task bundle-install` and `task migrate-dev`. All these commands are set up to
+run in the docker environment.
+
+
 ## Running tests
 
 Assuming you have your local environment going, the easiest way is to run them on docker:

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -1,0 +1,50 @@
+version: '3'
+
+tasks:
+  build:
+    desc: build the planorama container
+    cmds:
+      - docker-compose -f docker-compose-dev.yml build planorama
+  quickstart:
+    desc: 'start docker services without any building. Call as
+    task quickstart -- service_name to start just one service'
+    cmds:
+      - docker-compose -f docker-compose-dev.yml up -d {{.CLI_ARGS}}
+  start:
+    desc: 'build and start docker services. Use as
+    task start -- service_name
+    to start a specific service'
+    cmds:
+      - docker-compose -f docker-compose-dev.yml up --build -d {{.CLI_ARGS}}
+  restart:
+    desc: 'use without arguments to restart all services, or call as
+      task restart -- service_name
+      to restart a specific service'
+    cmds:
+      - docker-compose -f docker-compose-dev.yml restart {{.CLI_ARGS}}
+  stop:
+    desc: 'use without arguments to stop all services, or call as
+    task stop -- service_name to stop a specific service'
+    cmds:
+      - docker-compose -f docker-compose-dev.yml down {{.CLI_ARGS}}
+  bundle-install:
+    desc: runs bundle install in a docker container
+    cmds:
+      - docker-compose -f docker-compose-dev.yml run --rm --no-deps planorama bundle install
+  migrate-dev:
+    desc: Applies any new migrations to dev database
+    deps:
+      - task: quickstart
+        vars: { CLI_ARGS: 'postgres' }
+    cmds:
+      - docker-compose -f docker-compose-dev.yml run --rm --no-deps planorama bin/rails db:migrate {{.CLI_ARGS}}
+  psql:
+    desc: gives you a psql shell against the running dev database
+    dotenv:
+      - '.envrc'
+    cmds:
+      - docker-compose -f docker-compose-dev.yml exec postgres psql -U $POSTGRES_USER -d planorama_development
+  rails-console:
+    desc: runs a rails console in the docker environment
+    cmds:
+      - docker-compose -f docker-compose-dev.yml run --rm --no-deps planorama bin/rails c


### PR DESCRIPTION
This adds the ability to use [Task](https://taskfile.dev/) which is basically just a tool that lets you save commands that you need to run frequently. I added most of the things that were in `docker.rake` to `Taskfile.yaml`, and added instructions to the Readme. The changes to Gemfile.lock are just due to running `bundle install` locally for the sake of my IDE.