### PR TITLE
Add annotate gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -101,6 +101,7 @@ group :development do
   gem 'guard'
   gem 'guard-livereload'
   gem 'rack-livereload'
+  gem 'annotate'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,6 +76,9 @@ GEM
       activerecord (>= 6.0, < 7.1)
     addressable (2.8.5)
       public_suffix (>= 2.0.2, < 6.0)
+    annotate (3.2.0)
+      activerecord (>= 3.2, < 8.0)
+      rake (>= 10.4, < 14.0)
     ast (2.4.2)
     base64 (0.1.1)
     bcrypt (3.1.19)
@@ -483,6 +486,7 @@ DEPENDENCIES
   active_model_serializers (~> 0.10.0)
   activerecord-postgres_enum
   acts-as-taggable-on (~> 9.0)
+  annotate
   bootsnap (>= 1.4.4)
   brakeman
   bundler-audit

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -36,6 +36,7 @@ tasks:
     deps:
       - task: quickstart
         vars: { CLI_ARGS: 'postgres' }
+      - task: build
     cmds:
       - docker-compose -f docker-compose-dev.yml run --rm --no-deps planorama bin/rails db:migrate {{.CLI_ARGS}}
   psql:

--- a/app/models/age_restriction.rb
+++ b/app/models/age_restriction.rb
@@ -1,3 +1,13 @@
+# == Schema Information
+#
+# Table name: age_restrictions
+#
+#  id           :uuid             not null, primary key
+#  lock_version :integer
+#  name         :string(500)
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
 class AgeRestriction < ApplicationRecord
   validates :name, presence: true
 

--- a/app/models/agreement.rb
+++ b/app/models/agreement.rb
@@ -1,3 +1,25 @@
+# == Schema Information
+#
+# Table name: agreements
+#
+#  id             :uuid             not null, primary key
+#  agreement_type :string
+#  description    :string(10000)
+#  lock_version   :integer          default(0)
+#  target         :enum
+#  terms          :text
+#  title          :string
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  created_by_id  :uuid             not null
+#  updated_by_id  :uuid             not null
+#
+# Indexes
+#
+#  index_agreements_on_created_by_id  (created_by_id)
+#  index_agreements_on_target         (target)
+#  index_agreements_on_updated_by_id  (updated_by_id)
+#
 class Agreement < ApplicationRecord
   enum target: { none: 'none', participant: 'participant', staff: 'staff', all: 'all' }, _suffix: true
 

--- a/app/models/application_role.rb
+++ b/app/models/application_role.rb
@@ -1,3 +1,19 @@
+# == Schema Information
+#
+# Table name: application_roles
+#
+#  id               :uuid             not null, primary key
+#  con_roles        :text             default([]), is an Array
+#  lock_version     :integer          default(0)
+#  name             :string           not null
+#  sensitive_access :boolean          default(FALSE)
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#
+# Indexes
+#
+#  index_application_roles_on_con_roles  (con_roles) USING gin
+#
 #
 class ApplicationRole < ApplicationRecord
   has_many :model_permissions, dependent: :destroy

--- a/app/models/area.rb
+++ b/app/models/area.rb
@@ -1,3 +1,18 @@
+# == Schema Information
+#
+# Table name: areas
+#
+#  id           :uuid             not null, primary key
+#  lock_version :integer          default(0)
+#  name         :string
+#  sort_order   :integer
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
+# Indexes
+#
+#  index_areas_on_name  (name) UNIQUE
+#
 class Area < ApplicationRecord
   include RankedModel
   ranks :sort_order

--- a/app/models/audit/person_version.rb
+++ b/app/models/audit/person_version.rb
@@ -1,3 +1,20 @@
+# == Schema Information
+#
+# Table name: audit_people_versions
+#
+#  id             :bigint           not null, primary key
+#  event          :string           not null
+#  item_type      :string           not null
+#  object         :json
+#  object_changes :json
+#  whodunnit      :string
+#  created_at     :datetime
+#  item_id        :uuid             not null
+#
+# Indexes
+#
+#  index_audit_people_versions_on_item_type_and_item_id  (item_type,item_id)
+#
 module Audit
   class PersonVersion < PaperTrail::Version
     self.table_name = :audit_people_versions

--- a/app/models/audit/published_session_version.rb
+++ b/app/models/audit/published_session_version.rb
@@ -1,3 +1,20 @@
+# == Schema Information
+#
+# Table name: audit_published_session_versions
+#
+#  id             :bigint           not null, primary key
+#  event          :string           not null
+#  item_type      :string           not null
+#  object         :json
+#  object_changes :json
+#  whodunnit      :string
+#  created_at     :datetime
+#  item_id        :uuid             not null
+#
+# Indexes
+#
+#  index_audit_published_session_versions_on_item_type_and_item_id  (item_type,item_id)
+#
 module Audit
   class PublishedSessionVersion < PaperTrail::Version
     self.table_name = :audit_published_session_versions

--- a/app/models/audit/session_version.rb
+++ b/app/models/audit/session_version.rb
@@ -1,3 +1,20 @@
+# == Schema Information
+#
+# Table name: audit_session_versions
+#
+#  id             :bigint           not null, primary key
+#  event          :string           not null
+#  item_type      :string           not null
+#  object         :json
+#  object_changes :json
+#  whodunnit      :string
+#  created_at     :datetime
+#  item_id        :uuid             not null
+#
+# Indexes
+#
+#  index_audit_session_versions_on_item_type_and_item_id  (item_type,item_id)
+#
 module Audit
   class SessionVersion < PaperTrail::Version
     self.table_name = :audit_session_versions

--- a/app/models/audit/survey_version.rb
+++ b/app/models/audit/survey_version.rb
@@ -1,3 +1,20 @@
+# == Schema Information
+#
+# Table name: audit_survey_versions
+#
+#  id             :bigint           not null, primary key
+#  event          :string           not null
+#  item_type      :string           not null
+#  object         :json
+#  object_changes :json
+#  whodunnit      :string
+#  created_at     :datetime
+#  item_id        :uuid             not null
+#
+# Indexes
+#
+#  index_audit_survey_versions_on_item_type_and_item_id  (item_type,item_id)
+#
 module Audit
   class SurveyVersion < PaperTrail::Version
     self.table_name = :audit_survey_versions

--- a/app/models/availability.rb
+++ b/app/models/availability.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: availabilities
+#
+#  id           :uuid             not null, primary key
+#  end_time     :datetime
+#  lock_version :integer
+#  start_time   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  person_id    :uuid
+#
 class Availability < ApplicationRecord
   belongs_to :person
   validates :person_id, presence: true

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,3 +1,22 @@
+# == Schema Information
+#
+# Table name: categories
+#
+#  id           :uuid             not null, primary key
+#  active       :boolean          default(TRUE), not null
+#  description  :string
+#  name         :string(191)      not null
+#  reserved     :boolean          default(FALSE), not null
+#  target_class :string(100)
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
+# Indexes
+#
+#  by_active_status          (active)
+#  by_name_and_target_class  (name,target_class) UNIQUE
+#  by_reserved_status        (reserved)
+#
 class Category < ApplicationRecord
   belongs_to :category_name
   belongs_to :categorized, polymorphic: true

--- a/app/models/configuration.rb
+++ b/app/models/configuration.rb
@@ -1,3 +1,23 @@
+# == Schema Information
+#
+# Table name: configurations
+#
+#  id              :uuid             not null, primary key
+#  lock_version    :integer          default(0)
+#  parameter       :string(45)       not null
+#  parameter_value :string(150)      not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#
+# Indexes
+#
+#  fk_configurations_parameters_idx  (parameter)
+#  fl_configurations_unique_index    (parameter) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_configurations_parameters  (parameter => parameter_names.parameter_name)
+#
 class Configuration < ApplicationRecord
   belongs_to :parameter_name, foreign_key: 'parameter', inverse_of: :configuration
 end

--- a/app/models/conflict_exception.rb
+++ b/app/models/conflict_exception.rb
@@ -1,4 +1,18 @@
-# require 'planner_utils'
+# == Schema Information
+#
+# Table name: conflict_exceptions
+#
+#  id            :uuid             not null, primary key
+#  affected      :integer
+#  conflict_type :string
+#  idx           :bigint
+#  lock_version  :integer          default(0)
+#  note          :text
+#  src1          :integer
+#  src2          :integer
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#
 class ConflictException < ApplicationRecord
   validates_inclusion_of :conflict_type,
                          in: %i[schedule room item avail time back2back]

--- a/app/models/conflicts/availability_conflict.rb
+++ b/app/models/conflicts/availability_conflict.rb
@@ -1,3 +1,21 @@
+# == Schema Information
+#
+# Table name: availability_conflicts
+#
+#  id                              :text             primary key
+#  person_name                     :string
+#  person_published_name           :string
+#  session_assignment_name         :string(100)
+#  session_assignment_role_type    :enum
+#  session_duration                :integer
+#  session_start_time              :datetime
+#  session_title                   :string(256)
+#  person_id                       :uuid
+#  session_assignment_id           :uuid
+#  session_assignment_role_type_id :uuid
+#  session_id                      :uuid
+#  session_room_id                 :uuid
+#
 class Conflicts::AvailabilityConflict < ApplicationRecord
   self.table_name = :availability_conflicts
   self.primary_key = :id

--- a/app/models/conflicts/person_back_to_back.rb
+++ b/app/models/conflicts/person_back_to_back.rb
@@ -1,3 +1,32 @@
+# == Schema Information
+#
+# Table name: person_back_to_back
+#
+#  id                                       :text             primary key
+#  con_state                                :enum
+#  conflict_duration                        :integer
+#  conflict_end_time                        :datetime
+#  conflict_session_assignment_name         :string(100)
+#  conflict_session_assignment_role_type    :enum
+#  conflict_session_title                   :string(256)
+#  conflict_start_time                      :datetime
+#  duration                                 :integer
+#  end_time                                 :datetime
+#  name                                     :string
+#  published_name                           :string
+#  session_assignment_name                  :string(100)
+#  session_assignment_role_type             :enum
+#  start_time                               :datetime
+#  title                                    :string(256)
+#  conflict_room_id                         :uuid
+#  conflict_session_assignment_role_type_id :uuid
+#  conflict_session_id                      :uuid
+#  person_id                                :uuid
+#  room_id                                  :uuid
+#  session_assignment_id                    :uuid
+#  session_assignment_role_type_id          :uuid
+#  session_id                               :uuid
+#
 class Conflicts::PersonBackToBack < ApplicationRecord
   self.table_name = :person_back_to_back
   self.primary_key = :id

--- a/app/models/conflicts/person_back_to_back_to_back.rb
+++ b/app/models/conflicts/person_back_to_back_to_back.rb
@@ -1,3 +1,44 @@
+# == Schema Information
+#
+# Table name: person_back_to_back_to_back
+#
+#  id                                       :text             primary key
+#  con_state                                :enum
+#  conflict_duration                        :integer
+#  conflict_end_time                        :datetime
+#  conflict_session_assignment_name         :string(100)
+#  conflict_session_assignment_role_type    :enum
+#  conflict_session_title                   :string(256)
+#  conflict_start_time                      :datetime
+#  duration                                 :integer
+#  end_time                                 :datetime
+#  middle_duration                          :integer
+#  middle_end_time                          :datetime
+#  middle_session_assignment_name           :string(100)
+#  middle_session_assignment_role_type      :enum
+#  middle_start_time                        :datetime
+#  middle_title                             :string(256)
+#  name                                     :string
+#  published_name                           :string
+#  session_assignment_name                  :string(100)
+#  session_assignment_role_type             :enum
+#  start_time                               :datetime
+#  title                                    :string(256)
+#  b2b_id                                   :text
+#  conflict_b2b_id                          :text
+#  conflict_room_id                         :uuid
+#  conflict_session_assignment_role_type_id :uuid
+#  conflict_session_id                      :uuid
+#  middle_room_id                           :uuid
+#  middle_session_assignment_id             :uuid
+#  middle_session_assignment_role_type_id   :uuid
+#  middle_session_id                        :uuid
+#  person_id                                :uuid
+#  room_id                                  :uuid
+#  session_assignment_id                    :uuid
+#  session_assignment_role_type_id          :uuid
+#  session_id                               :uuid
+#
 class Conflicts::PersonBackToBackToBack < ApplicationRecord
   self.table_name = :person_back_to_back_to_back
   self.primary_key = :id

--- a/app/models/conflicts/person_exclusion_conflict.rb
+++ b/app/models/conflicts/person_exclusion_conflict.rb
@@ -1,3 +1,26 @@
+# == Schema Information
+#
+# Table name: person_exclusion_conflicts
+#
+#  id                              :text             primary key
+#  con_state                       :enum
+#  duration                        :integer
+#  end_time                        :datetime
+#  excluded_session_title          :string(256)
+#  name                            :string
+#  published_name                  :string
+#  session_assignment_name         :string(100)
+#  session_assignment_role_type    :enum
+#  start_time                      :datetime
+#  title                           :string(256)
+#  excluded_session_id             :uuid
+#  exclusion_id                    :uuid
+#  person_id                       :uuid
+#  room_id                         :uuid
+#  session_assignment_id           :uuid
+#  session_assignment_role_type_id :uuid
+#  session_id                      :uuid
+#
 class Conflicts::PersonExclusionConflict < ApplicationRecord
   self.table_name = :person_exclusion_conflicts
   self.primary_key = :id

--- a/app/models/conflicts/person_schedule_conflict.rb
+++ b/app/models/conflicts/person_schedule_conflict.rb
@@ -1,3 +1,32 @@
+# == Schema Information
+#
+# Table name: person_schedule_conflicts
+#
+#  id                                       :text             primary key
+#  con_state                                :enum
+#  conflict_duration                        :integer
+#  conflict_end_time                        :datetime
+#  conflict_session_assignment_name         :string(100)
+#  conflict_session_assignment_role_type    :enum
+#  conflict_session_title                   :string(256)
+#  conflict_start_time                      :datetime
+#  duration                                 :integer
+#  end_time                                 :datetime
+#  name                                     :string
+#  published_name                           :string
+#  session_assignment_name                  :string(100)
+#  session_assignment_role_type             :enum
+#  start_time                               :datetime
+#  title                                    :string(256)
+#  conflict_room_id                         :uuid
+#  conflict_session_assignment_role_type_id :uuid
+#  conflict_session_id                      :uuid
+#  person_id                                :uuid
+#  room_id                                  :uuid
+#  session_assignment_id                    :uuid
+#  session_assignment_role_type_id          :uuid
+#  session_id                               :uuid
+#
 class Conflicts::PersonScheduleConflict < ApplicationRecord
   self.table_name = :person_schedule_conflicts
   self.primary_key = :id

--- a/app/models/conflicts/room_conflict.rb
+++ b/app/models/conflicts/room_conflict.rb
@@ -1,3 +1,21 @@
+# == Schema Information
+#
+# Table name: room_conflicts
+#
+#  id                             :text             primary key
+#  back_to_back                   :boolean
+#  conflicting_session_duration   :integer
+#  conflicting_session_end_time   :datetime
+#  conflicting_session_start_time :datetime
+#  conflicting_session_title      :string(256)
+#  duration                       :integer
+#  end_time                       :datetime
+#  session_title                  :string(256)
+#  start_time                     :datetime
+#  conflicting_session_id         :uuid
+#  room_id                        :uuid
+#  session_id                     :uuid
+#
 class Conflicts::RoomConflict < ApplicationRecord
   self.table_name = :room_conflicts
   self.primary_key = :id

--- a/app/models/conflicts/session_conflict.rb
+++ b/app/models/conflicts/session_conflict.rb
@@ -1,3 +1,27 @@
+# == Schema Information
+#
+# Table name: session_conflicts
+#
+#  conflict_session_assignment_name         :text
+#  conflict_session_duration                :integer
+#  conflict_session_start_time              :datetime
+#  conflict_session_title                   :string
+#  conflict_type                            :text
+#  person_name                              :string
+#  person_published_name                    :string
+#  session_assignment_name                  :string
+#  session_duration                         :integer
+#  session_start_time                       :datetime
+#  session_title                            :string(256)
+#  conflict_id                              :text             primary key
+#  conflict_session_assignment_role_type_id :uuid
+#  conflict_session_id                      :uuid
+#  person_id                                :uuid
+#  room_id                                  :uuid
+#  session_assignment_id                    :uuid
+#  session_assignment_role_type_id          :uuid
+#  session_id                               :uuid
+#
 class Conflicts::SessionConflict < ApplicationRecord
   self.table_name = :session_conflicts
   self.primary_key = :conflict_id

--- a/app/models/convention_role.rb
+++ b/app/models/convention_role.rb
@@ -1,3 +1,18 @@
+# == Schema Information
+#
+# Table name: convention_roles
+#
+#  id           :uuid             not null, primary key
+#  lock_version :integer
+#  role         :enum
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  person_id    :uuid
+#
+# Indexes
+#
+#  index_convention_roles_on_person_id  (person_id)
+#
 class ConventionRole < ApplicationRecord
   belongs_to :person
 

--- a/app/models/email_address.rb
+++ b/app/models/email_address.rb
@@ -1,3 +1,22 @@
+# == Schema Information
+#
+# Table name: email_addresses
+#
+#  id           :uuid             not null, primary key
+#  email        :string           default("")
+#  is_valid     :boolean          default(TRUE), not null
+#  iscontact    :boolean          default(FALSE)
+#  isdefault    :boolean          default(FALSE), not null
+#  label        :string
+#  lock_version :integer          default(0)
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  person_id    :uuid
+#
+# Indexes
+#
+#  index_email_addresses_on_email  (email) USING gin
+#
 class SinglePrimaryEmail < ActiveModel::Validator
   def validate(record)
     emails = EmailAddress.where(isdefault: true, email: record.email).where("person_id != ?", record.person_id)

--- a/app/models/exclusion.rb
+++ b/app/models/exclusion.rb
@@ -1,3 +1,13 @@
+# == Schema Information
+#
+# Table name: exclusions
+#
+#  id           :uuid             not null, primary key
+#  lock_version :integer
+#  title        :string(800)      not null
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
 class Exclusion < ApplicationRecord
   # title - text 500 chars
   validates :title, presence: true

--- a/app/models/format.rb
+++ b/app/models/format.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: formats
+#
+#  id           :uuid             not null, primary key
+#  lock_version :integer          default(0)
+#  name         :string           not null
+#  position     :integer
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
 class Format < ApplicationRecord
   has_many :sessions
   has_many :published_sessions

--- a/app/models/ignored_conflict.rb
+++ b/app/models/ignored_conflict.rb
@@ -1,2 +1,16 @@
+# == Schema Information
+#
+# Table name: ignored_conflicts
+#
+#  id            :uuid             not null, primary key
+#  conflict_type :string
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  conflict_id   :string(2048)
+#
+# Indexes
+#
+#  index_ignored_conflicts_on_conflict_id_and_conflict_type  (conflict_id,conflict_type) UNIQUE
+#
 class IgnoredConflict < ApplicationRecord
 end

--- a/app/models/integration.rb
+++ b/app/models/integration.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: integrations
+#
+#  id           :uuid             not null, primary key
+#  config       :jsonb            not null
+#  lock_version :integer          default(0)
+#  name         :string
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
 class Integration < ApplicationRecord
   scope :login, ->  { where("config @> ?", '{"type": "login", "enabled": true}')}
 end

--- a/app/models/label_dimensions.rb
+++ b/app/models/label_dimensions.rb
@@ -1,2 +1,25 @@
+# == Schema Information
+#
+# Table name: label_dimensions
+#
+#  id                 :uuid             not null, primary key
+#  across             :integer
+#  bottom_margin      :float
+#  down               :integer
+#  horizontal_spacing :float
+#  label_height       :float
+#  label_width        :float
+#  left_margin        :float
+#  manufacturer       :string
+#  name               :string
+#  orientation        :string
+#  page_size          :string
+#  right_margin       :float
+#  top_margin         :float
+#  unit               :string
+#  vertical_spacing   :float
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#
 class LabelDimensions < ApplicationRecord
 end

--- a/app/models/magic_link.rb
+++ b/app/models/magic_link.rb
@@ -1,3 +1,20 @@
+# == Schema Information
+#
+# Table name: magic_links
+#
+#  id           :uuid             not null, primary key
+#  expires_at   :datetime         not null
+#  lock_version :integer          default(0)
+#  token        :string           not null
+#  url          :string(10000)
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  person_id    :uuid             not null
+#
+# Indexes
+#
+#  index_magic_links_on_person_id  (person_id)
+#
 class MagicLink < ApplicationRecord
   belongs_to :person
 end

--- a/app/models/mail_history.rb
+++ b/app/models/mail_history.rb
@@ -1,3 +1,21 @@
+# == Schema Information
+#
+# Table name: mail_histories
+#
+#  id                           :uuid             not null, primary key
+#  content                      :text
+#  date_sent                    :datetime
+#  email                        :string
+#  email_status                 :enum
+#  lock_version                 :integer          default(0)
+#  subject                      :string
+#  testrun                      :boolean          default(FALSE)
+#  created_at                   :datetime         not null
+#  updated_at                   :datetime         not null
+#  mailing_id                   :uuid
+#  person_id                    :uuid
+#  person_mailing_assignment_id :uuid
+#
 class MailHistory < ApplicationRecord
   belongs_to :person, optional: true
   belongs_to :mailing, optional: true

--- a/app/models/mailing.rb
+++ b/app/models/mailing.rb
@@ -1,3 +1,29 @@
+# == Schema Information
+#
+# Table name: mailings
+#
+#  id                      :uuid             not null, primary key
+#  cc_all                  :boolean          default(FALSE)
+#  content                 :text
+#  date_sent               :datetime
+#  description             :text
+#  include_email           :boolean          default(TRUE)
+#  last_person_idx         :integer          default(-1)
+#  lock_version            :integer          default(0)
+#  mailing_state           :enum             default("draft")
+#  subject                 :string
+#  testrun                 :boolean          default(FALSE)
+#  title                   :string
+#  transiton_person_status :enum
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
+#  sent_by_id              :uuid
+#  survey_id               :uuid
+#
+# Indexes
+#
+#  index_mailings_on_mailing_state  (mailing_state)
+#
 class Mailing < ApplicationRecord
   has_many  :person_mailing_assignments, dependent: :destroy
   has_many  :people, through: :person_mailing_assignments

--- a/app/models/model_permission.rb
+++ b/app/models/model_permission.rb
@@ -1,3 +1,18 @@
+# == Schema Information
+#
+# Table name: model_permissions
+#
+#  actions             :jsonb
+#  lock_version        :integer
+#  mdl_name            :string           not null, primary key
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  application_role_id :uuid             not null, primary key
+#
+# Indexes
+#
+#  index_model_permissions_on_application_role_id  (application_role_id)
+#
 class ModelPermission < ApplicationRecord
   self.primary_keys = :mdl_name, :application_role_id
 

--- a/app/models/oauth_identity.rb
+++ b/app/models/oauth_identity.rb
@@ -1,3 +1,18 @@
+# == Schema Information
+#
+# Table name: oauth_identities
+#
+#  id           :uuid             not null, primary key
+#  email        :string
+#  lock_version :integer
+#  provider     :string
+#  raw_info     :jsonb            not null
+#  reg_number   :string
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  person_id    :uuid
+#  reg_id       :string
+#
 class OauthIdentity < ApplicationRecord
   belongs_to :person, optional: true
 end

--- a/app/models/old_password.rb
+++ b/app/models/old_password.rb
@@ -1,3 +1,18 @@
+# == Schema Information
+#
+# Table name: old_passwords
+#
+#  id                       :bigint           not null, primary key
+#  encrypted_password       :string           not null
+#  password_archivable_type :string           not null
+#  password_salt            :string
+#  created_at               :datetime
+#  password_archivable_id   :integer          not null
+#
+# Indexes
+#
+#  index_password_archivable  (password_archivable_type,password_archivable_id)
+#
 class OldPassword < ApplicationRecord
   belongs_to :password_archivable, polymorphic: true
 end

--- a/app/models/page_content.rb
+++ b/app/models/page_content.rb
@@ -1,2 +1,17 @@
+# == Schema Information
+#
+# Table name: page_contents
+#
+#  id           :uuid             not null, primary key
+#  html         :text             not null
+#  lock_version :integer
+#  name         :string           not null
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
+# Indexes
+#
+#  unique_page_content  (name) UNIQUE
+#
 class PageContent < ApplicationRecord
 end

--- a/app/models/parameter_name.rb
+++ b/app/models/parameter_name.rb
@@ -1,3 +1,11 @@
+# == Schema Information
+#
+# Table name: parameter_names
+#
+#  parameter_description :string(170)      not null
+#  parameter_name        :string(45)       not null, primary key
+#  parameter_type        :string           default("String")
+#
 class ParameterName < ApplicationRecord
   self.primary_key = 'parameter_name'
 

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -1,3 +1,99 @@
+# == Schema Information
+#
+# Table name: people
+#
+#  id                          :uuid             not null, primary key
+#  accommodations              :string(10000)
+#  age_at_convention           :string
+#  attendance_type             :string(200)
+#  availability_notes          :string
+#  bio                         :text
+#  black_diaspora              :string(10000)
+#  can_photo                   :enum             default("no")
+#  can_photo_exceptions        :string(10000)
+#  can_record                  :enum             default("no")
+#  can_record_exceptions       :string(10000)
+#  can_share                   :boolean          default(FALSE), not null
+#  can_stream                  :enum             default("no")
+#  can_stream_exceptions       :string(10000)
+#  comments                    :text
+#  con_state                   :enum             default("not_set")
+#  confirmation_sent_at        :datetime
+#  confirmation_token          :string
+#  confirmed_at                :datetime
+#  current_sign_in_at          :datetime
+#  current_sign_in_ip          :inet
+#  date_reg_synced             :datetime
+#  demographic_categories      :string
+#  do_not_assign_with          :string(10000)
+#  encrypted_password          :string           default(""), not null
+#  ethnicity                   :string(400)
+#  facebook                    :string
+#  failed_attempts             :integer          default(0), not null
+#  flickr                      :string
+#  gender                      :string(400)
+#  indigenous                  :string(10000)
+#  instagram                   :string
+#  integrations                :jsonb            not null
+#  is_local                    :boolean          default(FALSE)
+#  job_title                   :string
+#  language                    :string(5)        default("")
+#  languages_fluent_in         :string(10000)
+#  last_sign_in_at             :datetime
+#  last_sign_in_ip             :inet
+#  linkedin                    :string
+#  lock_version                :integer          default(0)
+#  locked_at                   :datetime
+#  moderation_experience       :string(10000)
+#  name                        :string           default("")
+#  name_sort_by                :string
+#  name_sort_by_confirmed      :boolean          default(FALSE)
+#  needs_accommodations        :boolean          default(FALSE)
+#  non_us_centric_perspectives :string(10000)
+#  opted_in                    :boolean          default(FALSE), not null
+#  organization                :string
+#  othered                     :string(10000)
+#  othersocialmedia            :string
+#  pronouns                    :string(400)
+#  pseudonym                   :string
+#  pseudonym_sort_by           :string
+#  pseudonym_sort_by_confirmed :boolean          default(FALSE)
+#  published_name              :string
+#  published_name_sort_by      :string
+#  reddit                      :string
+#  registered                  :boolean          default(FALSE), not null
+#  registration_number         :string
+#  registration_type           :string
+#  remember_created_at         :datetime
+#  reset_password_sent_at      :datetime
+#  reset_password_token        :string
+#  romantic_sexual_orientation :string
+#  sign_in_count               :integer          default(0), not null
+#  tiktok                      :string
+#  timezone                    :string(500)
+#  twelve_hour                 :boolean          default(TRUE)
+#  twitch                      :string
+#  twitter                     :string
+#  unconfirmed_email           :string
+#  unlock_token                :string
+#  website                     :string
+#  willing_to_moderate         :boolean          default(FALSE)
+#  year_of_birth               :integer
+#  youtube                     :string
+#  created_at                  :datetime         not null
+#  updated_at                  :datetime         not null
+#  reg_id                      :string
+#
+# Indexes
+#
+#  index_people_on_bio                   (bio) USING gin
+#  index_people_on_confirmation_token    (confirmation_token) UNIQUE
+#  index_people_on_name                  (name) USING gin
+#  index_people_on_pseudonym             (pseudonym) USING gin
+#  index_people_on_published_name        (published_name) USING gin
+#  index_people_on_reset_password_token  (reset_password_token) UNIQUE
+#  index_people_on_unlock_token          (unlock_token) UNIQUE
+#
 #
 class Person < ApplicationRecord
   # Include default devise modules. Others available are:

--- a/app/models/person_agreement.rb
+++ b/app/models/person_agreement.rb
@@ -1,3 +1,22 @@
+# == Schema Information
+#
+# Table name: person_agreements
+#
+#  id           :uuid             not null, primary key
+#  agreed_on    :datetime         not null
+#  lock_version :integer          default(0)
+#  signed       :boolean          default(FALSE)
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  agreement_id :uuid             not null
+#  person_id    :uuid             not null
+#
+# Indexes
+#
+#  index_person_agreements_on_agreement_id                (agreement_id)
+#  index_person_agreements_on_person_id                   (person_id)
+#  index_person_agreements_on_person_id_and_agreement_id  (person_id,agreement_id) UNIQUE
+#
 class PersonAgreement < ApplicationRecord
   belongs_to :person
   belongs_to :agreement

--- a/app/models/person_constraints.rb
+++ b/app/models/person_constraints.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: person_constraints
+#
+#  id                :uuid             not null, primary key
+#  lock_version      :integer          default(0)
+#  max_items_per_con :integer
+#  max_items_per_day :integer
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  person_id         :uuid
+#
 class PersonConstraints < ApplicationRecord
   belongs_to :person
 

--- a/app/models/person_exclusion.rb
+++ b/app/models/person_exclusion.rb
@@ -1,3 +1,19 @@
+# == Schema Information
+#
+# Table name: person_exclusions
+#
+#  id           :uuid             not null, primary key
+#  lock_version :integer
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  exclusion_id :uuid
+#  person_id    :uuid
+#
+# Indexes
+#
+#  index_person_exclusions_on_person_id                   (person_id)
+#  index_person_exclusions_on_person_id_and_exclusion_id  (person_id,exclusion_id) UNIQUE
+#
 class PersonExclusion < ApplicationRecord
   belongs_to  :person
   belongs_to  :exclusion

--- a/app/models/person_mailing_assignment.rb
+++ b/app/models/person_mailing_assignment.rb
@@ -1,3 +1,19 @@
+# == Schema Information
+#
+# Table name: person_mailing_assignments
+#
+#  id           :uuid             not null, primary key
+#  lock_version :integer          default(0)
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  mailing_id   :uuid
+#  person_id    :uuid
+#
+# Indexes
+#
+#  index_person_mailing_assignments_on_mailing_id  (mailing_id)
+#  index_person_mailing_assignments_on_person_id   (person_id)
+#
 class PersonMailingAssignment < ApplicationRecord
   belongs_to  :person
   belongs_to  :mailing

--- a/app/models/person_schedule.rb
+++ b/app/models/person_schedule.rb
@@ -1,3 +1,32 @@
+# == Schema Information
+#
+# Table name: person_schedules
+#
+#  id                              :text             primary key
+#  can_share                       :boolean
+#  con_state                       :enum
+#  description                     :text
+#  duration                        :integer
+#  end_time                        :datetime
+#  environment                     :enum
+#  name                            :string
+#  participant_notes               :text
+#  pronouns                        :string(400)
+#  published_name                  :string
+#  session_assignment_name         :string(100)
+#  session_assignment_role_type    :enum
+#  sort_order                      :integer
+#  start_time                      :datetime
+#  status                          :enum
+#  title                           :string(256)
+#  updated_at                      :datetime
+#  format_id                       :uuid
+#  person_id                       :uuid
+#  room_id                         :uuid
+#  session_assignment_id           :uuid
+#  session_assignment_role_type_id :uuid
+#  session_id                      :uuid
+#
 class PersonSchedule < ApplicationRecord
   self.table_name = :person_schedules
   self.primary_key = :id

--- a/app/models/person_schedule_approval.rb
+++ b/app/models/person_schedule_approval.rb
@@ -1,3 +1,20 @@
+# == Schema Information
+#
+# Table name: person_schedule_approvals
+#
+#  id                   :uuid             not null, primary key
+#  approved             :enum             default("not_set")
+#  comments             :text
+#  lock_version         :integer
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#  person_id            :uuid
+#  schedule_workflow_id :uuid
+#
+# Indexes
+#
+#  psa_person_wrkflw_idx  (person_id,schedule_workflow_id) UNIQUE
+#
 class PersonScheduleApproval < ApplicationRecord
   belongs_to :person
   belongs_to :schedule_workflow

--- a/app/models/person_schedule_snapshot.rb
+++ b/app/models/person_schedule_snapshot.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: person_schedule_snapshots
+#
+#  id                   :uuid             not null, primary key
+#  lock_version         :integer
+#  snapshot             :jsonb
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#  person_id            :uuid
+#  schedule_snapshot_id :uuid
+#
 class PersonScheduleSnapshot < ApplicationRecord
   belongs_to :schedule_snapshot
   belongs_to :person

--- a/app/models/publication_date.rb
+++ b/app/models/publication_date.rb
@@ -1,3 +1,20 @@
+# == Schema Information
+#
+# Table name: publication_dates
+#
+#  id                  :uuid             not null, primary key
+#  dropped_assignments :integer          default(0)
+#  dropped_sessions    :integer          default(0)
+#  lock_version        :integer          default(0)
+#  new_assignments     :integer          default(0)
+#  new_sessions        :integer          default(0)
+#  sent_external       :boolean          default(FALSE), not null
+#  timestamp           :datetime
+#  updated_assignments :integer          default(0)
+#  updated_sessions    :integer          default(0)
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#
 class PublicationDate < ApplicationRecord
   has_many :publish_snapshots do
     def schedules

--- a/app/models/publication_status.rb
+++ b/app/models/publication_status.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: publication_statuses
+#
+#  id           :uuid             not null, primary key
+#  lock_version :integer          default(0)
+#  status       :string
+#  submit_time  :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
 class PublicationStatus < ApplicationRecord
   validates_inclusion_of :status, in: %w[inprogress completed]
 end

--- a/app/models/publish_snapshot.rb
+++ b/app/models/publish_snapshot.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: publish_snapshots
+#
+#  id                  :uuid             not null, primary key
+#  label               :string
+#  snapshot            :jsonb
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  publication_date_id :uuid
+#
 class PublishSnapshot < ApplicationRecord
   validates_inclusion_of :label, in: %w[schedule participants]
 

--- a/app/models/published_session.rb
+++ b/app/models/published_session.rb
@@ -1,3 +1,34 @@
+# == Schema Information
+#
+# Table name: published_sessions
+#
+#  audience_size        :integer
+#  description          :text
+#  duration             :integer
+#  environment          :enum             default("unknown")
+#  integrations         :jsonb            not null
+#  is_break             :boolean          default(FALSE)
+#  lock_version         :integer          default(0)
+#  minors_participation :jsonb
+#  participant_notes    :text
+#  pub_reference_number :integer
+#  recorded             :boolean          default(FALSE), not null
+#  require_signup       :boolean          default(FALSE)
+#  start_time           :datetime
+#  streamed             :boolean          default(FALSE), not null
+#  title                :string
+#  visibility           :enum             default("is_public")
+#  waiting_list_size    :integer          default(0)
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#  format_id            :uuid
+#  room_id              :uuid
+#  session_id           :uuid             not null, primary key
+#
+# Indexes
+#
+#  index_published_sessions_on_format_id  (format_id)
+#
 #
 #
 #

--- a/app/models/published_session_assignment.rb
+++ b/app/models/published_session_assignment.rb
@@ -1,3 +1,24 @@
+# == Schema Information
+#
+# Table name: published_session_assignments
+#
+#  integrations                    :jsonb            not null
+#  lock_version                    :integer          default(0)
+#  sort_order                      :integer
+#  visibility                      :enum             default("is_public")
+#  created_at                      :datetime         not null
+#  updated_at                      :datetime         not null
+#  person_id                       :uuid             not null
+#  published_session_id            :uuid             not null
+#  session_assignment_id           :uuid             not null, primary key
+#  session_assignment_role_type_id :uuid             not null
+#
+# Indexes
+#
+#  index_published_programme_item_assignments_on_person_id  (person_id)
+#  pub_progitem_assignment_item_index                       (published_session_id)
+#  pub_progitem_assignment_person_index                     (person_id)
+#
 class PublishedSessionAssignment < ApplicationRecord
   self.primary_key = :session_assignment_id
 

--- a/app/models/registration/registration_map_count.rb
+++ b/app/models/registration/registration_map_count.rb
@@ -1,7 +1,11 @@
-# This uses a View to count the potential map from
-# reg to people using names and/or email
-# For each unique person reg data pair it counts the number of matches
-# ideally there should be 2 (one for email and one for name)
+# == Schema Information
+#
+# Table name: registration_map_counts
+#
+#  pid       :uuid             primary key
+#  sub_count :bigint
+#  reg_id    :string           primary key
+#
 class Registration::RegistrationMapCount < ApplicationRecord
   self.table_name = :registration_map_counts
   self.primary_keys = :reg_id, :pid

--- a/app/models/registration/registration_map_people_count.rb
+++ b/app/models/registration/registration_map_people_count.rb
@@ -1,6 +1,9 @@
-# 
-# Count of how many matches there are per person id based on the map_reg count
-#  if > 1 then there are multiple potential people mapped to same reg id
+# == Schema Information
+#
+# Table name: registration_map_people_counts
+#
+#  count :bigint
+#  pid   :uuid             primary key
 #
 class Registration::RegistrationMapPeopleCount < ApplicationRecord
   self.table_name = :registration_map_people_counts

--- a/app/models/registration/registration_map_reg_count.rb
+++ b/app/models/registration/registration_map_reg_count.rb
@@ -1,7 +1,10 @@
-# 
-# Count of how many matches there are per reg id based on the map_reg count
-#  if > 1 then there are multiple potential reg data mapped to same person
-# 
+# == Schema Information
+#
+# Table name: registration_map_reg_counts
+#
+#  count  :bigint
+#  reg_id :string           primary key
+#
 class Registration::RegistrationMapRegCount < ApplicationRecord
   self.table_name = :registration_map_reg_counts
   self.primary_keys = :reg_id

--- a/app/models/registration/registration_sync_match.rb
+++ b/app/models/registration/registration_sync_match.rb
@@ -1,5 +1,14 @@
-# This uses a View to of the potential map from
-# reg to people using names and/or email
+# == Schema Information
+#
+# Table name: registration_sync_matches
+#
+#  email  :string
+#  mtype  :text             primary key
+#  name   :string
+#  pid    :uuid
+#  rid    :uuid             primary key
+#  reg_id :string
+#
 class Registration::RegistrationSyncMatch < ApplicationRecord
   self.table_name = :registration_sync_matches
   self.primary_keys = :rid, :mtype

--- a/app/models/registration_sync_datum.rb
+++ b/app/models/registration_sync_datum.rb
@@ -1,7 +1,26 @@
-# 
-# This is a table that contains the information that we got from
-# the convenstions registration system ...
-# 
+# == Schema Information
+#
+# Table name: registration_sync_data
+#
+#  id                  :uuid             not null, primary key
+#  alternative_email   :string
+#  email               :string
+#  lock_version        :integer
+#  name                :string
+#  preferred_name      :string
+#  raw_info            :jsonb            not null
+#  registration_number :string
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  reg_id              :string
+#
+# Indexes
+#
+#  index_registration_sync_data_on_email                (email) USING gin
+#  index_registration_sync_data_on_name                 (name) USING gin
+#  index_registration_sync_data_on_reg_id               (reg_id)
+#  index_registration_sync_data_on_registration_number  (registration_number)
+#
 class RegistrationSyncDatum < ApplicationRecord
   has_many :registration_sync_matches,
            class_name: 'Registration::RegistrationSyncMatch',

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -1,3 +1,35 @@
+# == Schema Information
+#
+# Table name: rooms
+#
+#  id                :uuid             not null, primary key
+#  area_of_space     :decimal(, )
+#  capacity          :integer
+#  comment           :text
+#  floor             :string
+#  height            :decimal(, )
+#  integrations      :jsonb            not null
+#  is_virtual        :boolean          default(FALSE)
+#  length            :decimal(, )
+#  lock_version      :integer          default(0)
+#  name              :string(490)      not null
+#  open_for_schedule :boolean          default(TRUE)
+#  purpose           :string
+#  sort_order        :integer
+#  width             :decimal(, )
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  room_set_id       :uuid
+#  venue_id          :uuid
+#
+# Indexes
+#
+#  index_rooms_on_room_set_id  (room_set_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (room_set_id => room_sets.id)
+#
 class Room < ApplicationRecord
   before_destroy :check_for_use
 

--- a/app/models/room_service.rb
+++ b/app/models/room_service.rb
@@ -1,3 +1,13 @@
+# == Schema Information
+#
+# Table name: room_services
+#
+#  id           :uuid             not null, primary key
+#  lock_version :integer
+#  name         :string(2000)
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
 class RoomService < ApplicationRecord
   validates :name, presence: true
 

--- a/app/models/room_set.rb
+++ b/app/models/room_set.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: room_sets
+#
+#  id           :uuid             not null, primary key
+#  description  :string
+#  lock_version :integer          default(0)
+#  name         :string
+#  sort_order   :integer
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
 class RoomSet < ApplicationRecord
   before_destroy :check_for_use
 

--- a/app/models/schedule_snapshot.rb
+++ b/app/models/schedule_snapshot.rb
@@ -1,3 +1,21 @@
+# == Schema Information
+#
+# Table name: schedule_snapshots
+#
+#  id           :uuid             not null, primary key
+#  completed_at :datetime
+#  created_by   :string
+#  label        :string
+#  lock_version :integer
+#  started_at   :datetime
+#  status       :enum             default("not_set")
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
+# Indexes
+#
+#  index_schedule_snapshots_on_label  (label) UNIQUE
+#
 class ScheduleSnapshot < ApplicationRecord
   validates_presence_of :label
 

--- a/app/models/schedule_workflow.rb
+++ b/app/models/schedule_workflow.rb
@@ -1,3 +1,20 @@
+# == Schema Information
+#
+# Table name: schedule_workflows
+#
+#  id                   :uuid             not null, primary key
+#  created_by           :string
+#  lock_version         :integer
+#  set_at               :datetime
+#  state                :enum             default("not_set")
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#  schedule_snapshot_id :uuid
+#
+# Indexes
+#
+#  index_schedule_workflows_on_schedule_snapshot_id  (schedule_snapshot_id) UNIQUE
+#
 class ScheduleWorkflow < ApplicationRecord
   belongs_to :schedule_snapshot, required: false, dependent: :destroy
 

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -1,3 +1,57 @@
+# == Schema Information
+#
+# Table name: sessions
+#
+#  id                        :uuid             not null, primary key
+#  audience_size             :integer
+#  description               :text
+#  duration                  :integer
+#  environment               :enum             default("unknown")
+#  instructions_for_interest :text
+#  interest_opened_at        :datetime
+#  interest_opened_by        :string
+#  is_break                  :boolean          default(FALSE)
+#  item_notes                :text
+#  lock_version              :integer          default(0)
+#  maximum_people            :integer
+#  minimum_people            :integer
+#  minors_participation      :jsonb
+#  open_for_interest         :boolean          default(FALSE)
+#  participant_notes         :text
+#  proofed                   :boolean          default(FALSE), not null
+#  pub_reference_number      :integer
+#  publish                   :boolean          default(FALSE), not null
+#  recorded                  :boolean          default(FALSE), not null
+#  require_signup            :boolean          default(FALSE)
+#  room_notes                :text
+#  start_time                :datetime
+#  status                    :enum             default("draft")
+#  streamed                  :boolean          default(FALSE), not null
+#  tech_notes                :text
+#  title                     :string(256)
+#  updated_by                :string
+#  visibility                :enum             default("is_public")
+#  waiting_list_size         :integer          default(0)
+#  created_at                :datetime         not null
+#  updated_at                :datetime         not null
+#  age_restriction_id        :uuid
+#  format_id                 :uuid
+#  room_id                   :uuid
+#  room_set_id               :uuid
+#
+# Indexes
+#
+#  index_sessions_on_description                (description) USING gin
+#  index_sessions_on_instructions_for_interest  (instructions_for_interest) USING gin
+#  index_sessions_on_interest_opened_by         (interest_opened_by) USING gin
+#  index_sessions_on_item_notes                 (item_notes) USING gin
+#  index_sessions_on_participant_notes          (participant_notes) USING gin
+#  index_sessions_on_room_id                    (room_id)
+#  index_sessions_on_room_notes                 (room_notes) USING gin
+#  index_sessions_on_tech_notes                 (tech_notes) USING gin
+#  index_sessions_on_title                      (title) USING gin
+#  index_sessions_on_updated_by                 (updated_by) USING gin
+#
 class Session < ApplicationRecord
   include XmlFormattable
 

--- a/app/models/session_area.rb
+++ b/app/models/session_area.rb
@@ -1,3 +1,19 @@
+# == Schema Information
+#
+# Table name: session_areas
+#
+#  id           :uuid             not null, primary key
+#  lock_version :integer
+#  primary      :boolean
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  area_id      :uuid
+#  session_id   :uuid
+#
+# Indexes
+#
+#  index_session_areas_on_session_id_and_area_id  (session_id,area_id) UNIQUE
+#
 class SessionArea < ApplicationRecord
   belongs_to  :area
   belongs_to  :session

--- a/app/models/session_assignment.rb
+++ b/app/models/session_assignment.rb
@@ -1,21 +1,30 @@
-## schema
-# CREATE TABLE public.session_assignments (
-#     id uuid DEFAULT public.gen_random_uuid() NOT NULL,
-#     person_id uuid NOT NULL,
-#     created_at timestamp without time zone NOT NULL,
-#     updated_at timestamp without time zone NOT NULL,
-#     lock_version integer DEFAULT 0,
-#     session_assignment_role_type_id uuid NOT NULL,
-#     session_id uuid NOT NULL,
-#     sort_order integer,
-#     visibility public.visibility_enum DEFAULT 'public'::public.visibility_enum,
-#     interested boolean DEFAULT false,
-#     interest_ranking integer,
-#     interest_notes text,
-#     interest_role_type uuid,
-#     state character varying,
-#     planner_notes text
-# );
+# == Schema Information
+#
+# Table name: session_assignments
+#
+#  id                              :uuid             not null, primary key
+#  interest_notes                  :text
+#  interest_ranking                :integer
+#  interest_role                   :enum             default("no_preference")
+#  interested                      :boolean          default(FALSE)
+#  lock_version                    :integer          default(0)
+#  planner_notes                   :text
+#  sort_order                      :integer
+#  state                           :string
+#  visibility                      :enum             default("is_public")
+#  created_at                      :datetime         not null
+#  updated_at                      :datetime         not null
+#  person_id                       :uuid             not null
+#  session_assignment_role_type_id :uuid
+#  session_id                      :uuid             not null
+#
+# Indexes
+#
+#  index_session_assignments_on_interest_role                    (interest_role)
+#  index_session_assignments_on_session_assignment_role_type_id  (session_assignment_role_type_id)
+#  pia_person_index                                              (person_id)
+#  pis_prog_item_id_index                                        (session_id)
+#
 class SessionAssignment < ApplicationRecord
   include RankedModel
   ranks :sort_order, with_same: [:session_id]

--- a/app/models/session_assignment_role_type.rb
+++ b/app/models/session_assignment_role_type.rb
@@ -1,3 +1,16 @@
+# == Schema Information
+#
+# Table name: session_assignment_role_type
+#
+#  id                 :uuid             not null, primary key
+#  default_visibility :enum             default("is_public")
+#  lock_version       :integer          default(0)
+#  name               :string(100)      not null
+#  role_type          :enum
+#  sort_order         :integer
+#  created_at         :datetime
+#  updated_at         :datetime
+#
 class SessionAssignmentRoleType < ApplicationRecord
   self.table_name = "session_assignment_role_type"
   include RankedModel

--- a/app/models/session_limit.rb
+++ b/app/models/session_limit.rb
@@ -1,3 +1,20 @@
+# == Schema Information
+#
+# Table name: session_limits
+#
+#  id           :uuid             not null, primary key
+#  day          :date
+#  lock_version :integer
+#  max_sessions :integer
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  person_id    :uuid
+#
+# Indexes
+#
+#  index_session_limits_on_person_id          (person_id)
+#  index_session_limits_on_person_id_and_day  (person_id,day) UNIQUE
+#
 class SingleGlobalForPerson < ActiveModel::Validator
   def validate(record)
     if record.day == nil

--- a/app/models/survey.rb
+++ b/app/models/survey.rb
@@ -1,4 +1,33 @@
-# If survey changed to multiple and there are already saved responses do not allow change
+# == Schema Information
+#
+# Table name: surveys
+#
+#  id                        :uuid             not null, primary key
+#  allow_submission_edits    :boolean          default(TRUE)
+#  authenticate_msg          :text
+#  branded                   :boolean          default(TRUE)
+#  declined_msg              :text
+#  description               :text
+#  lock_version              :integer          default(0)
+#  mandatory_star            :boolean          default(TRUE)
+#  name                      :string
+#  numbered_questions        :boolean          default(FALSE)
+#  public                    :boolean
+#  published_on              :datetime
+#  submit_string             :string           default("Save")
+#  thank_you                 :text
+#  transition_accept_status  :enum
+#  transition_decline_status :enum
+#  unassigned                :boolean          default(FALSE)
+#  unique_submission         :boolean          default(TRUE)
+#  use_captcha               :boolean          default(FALSE)
+#  welcome                   :text
+#  created_at                :datetime         not null
+#  updated_at                :datetime         not null
+#  created_by_id             :uuid
+#  published_by_id           :uuid
+#  updated_by_id             :uuid
+#
 class CheckChangeToMultiple < ActiveModel::Validator
   def validate(record)
     # We need to check if the survey is not unique whether there are submissions

--- a/app/models/survey/answer.rb
+++ b/app/models/survey/answer.rb
@@ -1,3 +1,24 @@
+# == Schema Information
+#
+# Table name: survey_answers
+#
+#  id               :uuid             not null, primary key
+#  answer           :text
+#  default          :boolean          default(FALSE)
+#  lock_version     :integer          default(0)
+#  next_page_action :enum             default("next_page")
+#  other            :boolean          default(FALSE)
+#  sort_order       :integer
+#  value            :string
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  next_page_id     :uuid
+#  question_id      :uuid
+#
+# Indexes
+#
+#  index_survey_answers_on_next_page_action  (next_page_action)
+#
 class Survey::Answer < ApplicationRecord
   include RankedModel
   ranks :sort_order, with_same: :question_id

--- a/app/models/survey/page.rb
+++ b/app/models/survey/page.rb
@@ -1,3 +1,25 @@
+# == Schema Information
+#
+# Table name: survey_pages
+#
+#  id               :uuid             not null, primary key
+#  next_page_action :enum             default("next_page")
+#  sort_order       :integer
+#  title            :string
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  next_page_id     :uuid
+#  survey_id        :uuid
+#
+# Indexes
+#
+#  index_survey_pages_on_next_page_action  (next_page_action)
+#  index_survey_pages_on_survey_id         (survey_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (survey_id => surveys.id)
+#
 class Survey::Page < ApplicationRecord
   include RankedModel
   ranks :sort_order, with_same: :survey_id

--- a/app/models/survey/query.rb
+++ b/app/models/survey/query.rb
@@ -1,4 +1,19 @@
-
+# == Schema Information
+#
+# Table name: survey_queries
+#
+#  id           :uuid             not null, primary key
+#  date_order   :boolean          default(FALSE)
+#  lock_version :integer          default(0)
+#  name         :string
+#  operation    :string
+#  shared       :boolean
+#  show_country :boolean          default(FALSE)
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  survey_id    :uuid
+#  user_id      :uuid
+#
 class Survey::Query < ApplicationRecord
   # queryPredicates
   has_many :survey_query_predicates, dependent: :destroy

--- a/app/models/survey/query_predicate.rb
+++ b/app/models/survey/query_predicate.rb
@@ -1,3 +1,16 @@
+# == Schema Information
+#
+# Table name: survey_query_predicates
+#
+#  id                 :uuid             not null, primary key
+#  lock_version       :integer          default(0)
+#  operation          :string
+#  value              :text
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  survey_query_id    :uuid
+#  survey_question_id :uuid
+#
 class Survey::QueryPredicate < ApplicationRecord
   belongs_to :survey_query
   belongs_to :survey_question

--- a/app/models/survey/question.rb
+++ b/app/models/survey/question.rb
@@ -1,3 +1,33 @@
+# == Schema Information
+#
+# Table name: survey_questions
+#
+#  id            :uuid             not null, primary key
+#  branching     :boolean          default(FALSE)
+#  deleted_at    :datetime
+#  horizontal    :boolean          default(FALSE)
+#  linked_field  :text
+#  lock_version  :integer          default(0)
+#  mandatory     :boolean          default(FALSE)
+#  private       :boolean          default(FALSE)
+#  question      :text
+#  question_type :string           default("textfield")
+#  randomize     :boolean          default(FALSE)
+#  regex         :string
+#  sort_order    :integer
+#  text_size     :integer
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  page_id       :uuid
+#
+# Indexes
+#
+#  index_survey_questions_on_page_id  (page_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (page_id => survey_pages.id)
+#
 class Survey::Question < ApplicationRecord
   include RankedModel
   ranks :sort_order, with_same: :page_id

--- a/app/models/survey/response.rb
+++ b/app/models/survey/response.rb
@@ -1,3 +1,25 @@
+# == Schema Information
+#
+# Table name: survey_responses
+#
+#  id               :uuid             not null, primary key
+#  lock_version     :integer          default(0)
+#  response         :jsonb
+#  response_as_text :text
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  question_id      :uuid             not null
+#  submission_id    :uuid             not null
+#
+# Indexes
+#
+#  index_survey_responses_on_submission_id  (submission_id)
+#  survey_resp_question_idx                 (question_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (submission_id => survey_submissions.id)
+#
 class Survey::Response < ApplicationRecord
   belongs_to :question,
              class_name: 'Survey::Question',

--- a/app/models/survey/submission.rb
+++ b/app/models/survey/submission.rb
@@ -1,5 +1,27 @@
-# If the survey is unique submission then a respondent is only
-# allow one submission...
+# == Schema Information
+#
+# Table name: survey_submissions
+#
+#  id               :uuid             not null, primary key
+#  lock_version     :integer          default(0)
+#  name             :string
+#  submission_state :enum             default("draft")
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  person_id        :uuid             not null
+#  survey_id        :uuid             not null
+#
+# Indexes
+#
+#  index_survey_submissions_on_person_id         (person_id)
+#  index_survey_submissions_on_submission_state  (submission_state)
+#  index_survey_submissions_on_survey_id         (survey_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (person_id => people.id)
+#  fk_rails_...  (survey_id => surveys.id)
+#
 class CheckUniqueSubmission < ActiveModel::Validator
   def validate(record)
     count = if record.id

--- a/app/models/tag_context.rb
+++ b/app/models/tag_context.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: tag_contexts
+#
+#  id           :uuid             not null, primary key
+#  lock_version :integer          default(0)
+#  name         :string
+#  publish      :boolean          default(TRUE)
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
 class TagContext < ApplicationRecord
   has_many :taggings,
            foreign_key: 'context',

--- a/app/models/venue.rb
+++ b/app/models/venue.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: venues
+#
+#  id           :uuid             not null, primary key
+#  address      :string
+#  lock_version :integer          default(0)
+#  name         :string
+#  sort_order   :integer
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
 class Venue < ApplicationRecord
   include RankedModel
   ranks :sort_order

--- a/app/serializers/agreement_serializer.rb
+++ b/app/serializers/agreement_serializer.rb
@@ -1,3 +1,25 @@
+# == Schema Information
+#
+# Table name: agreements
+#
+#  id             :uuid             not null, primary key
+#  agreement_type :string
+#  description    :string(10000)
+#  lock_version   :integer          default(0)
+#  target         :enum
+#  terms          :text
+#  title          :string
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  created_by_id  :uuid             not null
+#  updated_by_id  :uuid             not null
+#
+# Indexes
+#
+#  index_agreements_on_created_by_id  (created_by_id)
+#  index_agreements_on_target         (target)
+#  index_agreements_on_updated_by_id  (updated_by_id)
+#
 class AgreementSerializer
   include JSONAPI::Serializer
 

--- a/app/serializers/application_role_serializer.rb
+++ b/app/serializers/application_role_serializer.rb
@@ -1,3 +1,19 @@
+# == Schema Information
+#
+# Table name: application_roles
+#
+#  id               :uuid             not null, primary key
+#  con_roles        :text             default([]), is an Array
+#  lock_version     :integer          default(0)
+#  name             :string           not null
+#  sensitive_access :boolean          default(FALSE)
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#
+# Indexes
+#
+#  index_application_roles_on_con_roles  (con_roles) USING gin
+#
 class ApplicationRoleSerializer
   include JSONAPI::Serializer
 

--- a/app/serializers/area_serializer.rb
+++ b/app/serializers/area_serializer.rb
@@ -1,3 +1,18 @@
+# == Schema Information
+#
+# Table name: areas
+#
+#  id           :uuid             not null, primary key
+#  lock_version :integer          default(0)
+#  name         :string
+#  sort_order   :integer
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
+# Indexes
+#
+#  index_areas_on_name  (name) UNIQUE
+#
 class AreaSerializer
   include JSONAPI::Serializer
 

--- a/app/serializers/availability_serializer.rb
+++ b/app/serializers/availability_serializer.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: availabilities
+#
+#  id           :uuid             not null, primary key
+#  end_time     :datetime
+#  lock_version :integer
+#  start_time   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  person_id    :uuid
+#
 class AvailabilitySerializer
   include JSONAPI::Serializer
 

--- a/app/serializers/configuration_serializer.rb
+++ b/app/serializers/configuration_serializer.rb
@@ -1,3 +1,23 @@
+# == Schema Information
+#
+# Table name: configurations
+#
+#  id              :uuid             not null, primary key
+#  lock_version    :integer          default(0)
+#  parameter       :string(45)       not null
+#  parameter_value :string(150)      not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#
+# Indexes
+#
+#  fk_configurations_parameters_idx  (parameter)
+#  fl_configurations_unique_index    (parameter) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_configurations_parameters  (parameter => parameter_names.parameter_name)
+#
 class ConfigurationSerializer
   include JSONAPI::Serializer
 

--- a/app/serializers/conflicts/availability_conflict_serializer.rb
+++ b/app/serializers/conflicts/availability_conflict_serializer.rb
@@ -1,3 +1,21 @@
+# == Schema Information
+#
+# Table name: availability_conflicts
+#
+#  id                              :text             primary key
+#  person_name                     :string
+#  person_published_name           :string
+#  session_assignment_name         :string(100)
+#  session_assignment_role_type    :enum
+#  session_duration                :integer
+#  session_start_time              :datetime
+#  session_title                   :string(256)
+#  person_id                       :uuid
+#  session_assignment_id           :uuid
+#  session_assignment_role_type_id :uuid
+#  session_id                      :uuid
+#  session_room_id                 :uuid
+#
 class Conflicts::AvailabilityConflictSerializer
   include JSONAPI::Serializer
 

--- a/app/serializers/conflicts/session_conflict_serializer.rb
+++ b/app/serializers/conflicts/session_conflict_serializer.rb
@@ -1,3 +1,27 @@
+# == Schema Information
+#
+# Table name: session_conflicts
+#
+#  conflict_session_assignment_name         :text
+#  conflict_session_duration                :integer
+#  conflict_session_start_time              :datetime
+#  conflict_session_title                   :string
+#  conflict_type                            :text
+#  person_name                              :string
+#  person_published_name                    :string
+#  session_assignment_name                  :string
+#  session_duration                         :integer
+#  session_start_time                       :datetime
+#  session_title                            :string(256)
+#  conflict_id                              :text             primary key
+#  conflict_session_assignment_role_type_id :uuid
+#  conflict_session_id                      :uuid
+#  person_id                                :uuid
+#  room_id                                  :uuid
+#  session_assignment_id                    :uuid
+#  session_assignment_role_type_id          :uuid
+#  session_id                               :uuid
+#
 class Conflicts::SessionConflictSerializer
   include JSONAPI::Serializer
 

--- a/app/serializers/convention_role_serializer.rb
+++ b/app/serializers/convention_role_serializer.rb
@@ -1,3 +1,18 @@
+# == Schema Information
+#
+# Table name: convention_roles
+#
+#  id           :uuid             not null, primary key
+#  lock_version :integer
+#  role         :enum
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  person_id    :uuid
+#
+# Indexes
+#
+#  index_convention_roles_on_person_id  (person_id)
+#
 class ConventionRoleSerializer
   include JSONAPI::Serializer
 

--- a/app/serializers/email_address_serializer.rb
+++ b/app/serializers/email_address_serializer.rb
@@ -1,3 +1,22 @@
+# == Schema Information
+#
+# Table name: email_addresses
+#
+#  id           :uuid             not null, primary key
+#  email        :string           default("")
+#  is_valid     :boolean          default(TRUE), not null
+#  iscontact    :boolean          default(FALSE)
+#  isdefault    :boolean          default(FALSE), not null
+#  label        :string
+#  lock_version :integer          default(0)
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  person_id    :uuid
+#
+# Indexes
+#
+#  index_email_addresses_on_email  (email) USING gin
+#
 class EmailAddressSerializer
   include JSONAPI::Serializer
 

--- a/app/serializers/format_serializer.rb
+++ b/app/serializers/format_serializer.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: formats
+#
+#  id           :uuid             not null, primary key
+#  lock_version :integer          default(0)
+#  name         :string           not null
+#  position     :integer
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
 class FormatSerializer
   include JSONAPI::Serializer
 

--- a/app/serializers/integration_serializer.rb
+++ b/app/serializers/integration_serializer.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: integrations
+#
+#  id           :uuid             not null, primary key
+#  config       :jsonb            not null
+#  lock_version :integer          default(0)
+#  name         :string
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
 class IntegrationSerializer
   include JSONAPI::Serializer
 

--- a/app/serializers/mail_history_serializer.rb
+++ b/app/serializers/mail_history_serializer.rb
@@ -1,3 +1,21 @@
+# == Schema Information
+#
+# Table name: mail_histories
+#
+#  id                           :uuid             not null, primary key
+#  content                      :text
+#  date_sent                    :datetime
+#  email                        :string
+#  email_status                 :enum
+#  lock_version                 :integer          default(0)
+#  subject                      :string
+#  testrun                      :boolean          default(FALSE)
+#  created_at                   :datetime         not null
+#  updated_at                   :datetime         not null
+#  mailing_id                   :uuid
+#  person_id                    :uuid
+#  person_mailing_assignment_id :uuid
+#
 class MailHistorySerializer
   include JSONAPI::Serializer
 

--- a/app/serializers/mailing_serializer.rb
+++ b/app/serializers/mailing_serializer.rb
@@ -1,3 +1,29 @@
+# == Schema Information
+#
+# Table name: mailings
+#
+#  id                      :uuid             not null, primary key
+#  cc_all                  :boolean          default(FALSE)
+#  content                 :text
+#  date_sent               :datetime
+#  description             :text
+#  include_email           :boolean          default(TRUE)
+#  last_person_idx         :integer          default(-1)
+#  lock_version            :integer          default(0)
+#  mailing_state           :enum             default("draft")
+#  subject                 :string
+#  testrun                 :boolean          default(FALSE)
+#  title                   :string
+#  transiton_person_status :enum
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
+#  sent_by_id              :uuid
+#  survey_id               :uuid
+#
+# Indexes
+#
+#  index_mailings_on_mailing_state  (mailing_state)
+#
 class MailingSerializer
   include JSONAPI::Serializer
 

--- a/app/serializers/model_permission_serializer.rb
+++ b/app/serializers/model_permission_serializer.rb
@@ -1,3 +1,18 @@
+# == Schema Information
+#
+# Table name: model_permissions
+#
+#  actions             :jsonb
+#  lock_version        :integer
+#  mdl_name            :string           not null, primary key
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  application_role_id :uuid             not null, primary key
+#
+# Indexes
+#
+#  index_model_permissions_on_application_role_id  (application_role_id)
+#
 class ModelPermissionSerializer
   include JSONAPI::Serializer
 

--- a/app/serializers/oauth_identity_serializer.rb
+++ b/app/serializers/oauth_identity_serializer.rb
@@ -1,3 +1,18 @@
+# == Schema Information
+#
+# Table name: oauth_identities
+#
+#  id           :uuid             not null, primary key
+#  email        :string
+#  lock_version :integer
+#  provider     :string
+#  raw_info     :jsonb            not null
+#  reg_number   :string
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  person_id    :uuid
+#  reg_id       :string
+#
 class OauthIdentitySerializer
   include JSONAPI::Serializer
 

--- a/app/serializers/page_content_serializer.rb
+++ b/app/serializers/page_content_serializer.rb
@@ -1,3 +1,18 @@
+# == Schema Information
+#
+# Table name: page_contents
+#
+#  id           :uuid             not null, primary key
+#  html         :text             not null
+#  lock_version :integer
+#  name         :string           not null
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
+# Indexes
+#
+#  unique_page_content  (name) UNIQUE
+#
 class PageContentSerializer
   include JSONAPI::Serializer
 

--- a/app/serializers/parameter_name_serializer.rb
+++ b/app/serializers/parameter_name_serializer.rb
@@ -1,3 +1,11 @@
+# == Schema Information
+#
+# Table name: parameter_names
+#
+#  parameter_description :string(170)      not null
+#  parameter_name        :string(45)       not null, primary key
+#  parameter_type        :string           default("String")
+#
 class ParameterNameSerializer
   include JSONAPI::Serializer
 

--- a/app/serializers/person_exclusion_serializer.rb
+++ b/app/serializers/person_exclusion_serializer.rb
@@ -1,3 +1,19 @@
+# == Schema Information
+#
+# Table name: person_exclusions
+#
+#  id           :uuid             not null, primary key
+#  lock_version :integer
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  exclusion_id :uuid
+#  person_id    :uuid
+#
+# Indexes
+#
+#  index_person_exclusions_on_person_id                   (person_id)
+#  index_person_exclusions_on_person_id_and_exclusion_id  (person_id,exclusion_id) UNIQUE
+#
 class PersonExclusionSerializer
   include JSONAPI::Serializer
 

--- a/app/serializers/person_schedule_approval_serializer.rb
+++ b/app/serializers/person_schedule_approval_serializer.rb
@@ -1,3 +1,20 @@
+# == Schema Information
+#
+# Table name: person_schedule_approvals
+#
+#  id                   :uuid             not null, primary key
+#  approved             :enum             default("not_set")
+#  comments             :text
+#  lock_version         :integer
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#  person_id            :uuid
+#  schedule_workflow_id :uuid
+#
+# Indexes
+#
+#  psa_person_wrkflw_idx  (person_id,schedule_workflow_id) UNIQUE
+#
 class PersonScheduleApprovalSerializer
   include JSONAPI::Serializer
 

--- a/app/serializers/person_schedule_serializer.rb
+++ b/app/serializers/person_schedule_serializer.rb
@@ -1,3 +1,32 @@
+# == Schema Information
+#
+# Table name: person_schedules
+#
+#  id                              :text             primary key
+#  can_share                       :boolean
+#  con_state                       :enum
+#  description                     :text
+#  duration                        :integer
+#  end_time                        :datetime
+#  environment                     :enum
+#  name                            :string
+#  participant_notes               :text
+#  pronouns                        :string(400)
+#  published_name                  :string
+#  session_assignment_name         :string(100)
+#  session_assignment_role_type    :enum
+#  sort_order                      :integer
+#  start_time                      :datetime
+#  status                          :enum
+#  title                           :string(256)
+#  updated_at                      :datetime
+#  format_id                       :uuid
+#  person_id                       :uuid
+#  room_id                         :uuid
+#  session_assignment_id           :uuid
+#  session_assignment_role_type_id :uuid
+#  session_id                      :uuid
+#
 class PersonScheduleSerializer
 
   include JSONAPI::Serializer

--- a/app/serializers/person_serializer.rb
+++ b/app/serializers/person_serializer.rb
@@ -1,3 +1,99 @@
+# == Schema Information
+#
+# Table name: people
+#
+#  id                          :uuid             not null, primary key
+#  accommodations              :string(10000)
+#  age_at_convention           :string
+#  attendance_type             :string(200)
+#  availability_notes          :string
+#  bio                         :text
+#  black_diaspora              :string(10000)
+#  can_photo                   :enum             default("no")
+#  can_photo_exceptions        :string(10000)
+#  can_record                  :enum             default("no")
+#  can_record_exceptions       :string(10000)
+#  can_share                   :boolean          default(FALSE), not null
+#  can_stream                  :enum             default("no")
+#  can_stream_exceptions       :string(10000)
+#  comments                    :text
+#  con_state                   :enum             default("not_set")
+#  confirmation_sent_at        :datetime
+#  confirmation_token          :string
+#  confirmed_at                :datetime
+#  current_sign_in_at          :datetime
+#  current_sign_in_ip          :inet
+#  date_reg_synced             :datetime
+#  demographic_categories      :string
+#  do_not_assign_with          :string(10000)
+#  encrypted_password          :string           default(""), not null
+#  ethnicity                   :string(400)
+#  facebook                    :string
+#  failed_attempts             :integer          default(0), not null
+#  flickr                      :string
+#  gender                      :string(400)
+#  indigenous                  :string(10000)
+#  instagram                   :string
+#  integrations                :jsonb            not null
+#  is_local                    :boolean          default(FALSE)
+#  job_title                   :string
+#  language                    :string(5)        default("")
+#  languages_fluent_in         :string(10000)
+#  last_sign_in_at             :datetime
+#  last_sign_in_ip             :inet
+#  linkedin                    :string
+#  lock_version                :integer          default(0)
+#  locked_at                   :datetime
+#  moderation_experience       :string(10000)
+#  name                        :string           default("")
+#  name_sort_by                :string
+#  name_sort_by_confirmed      :boolean          default(FALSE)
+#  needs_accommodations        :boolean          default(FALSE)
+#  non_us_centric_perspectives :string(10000)
+#  opted_in                    :boolean          default(FALSE), not null
+#  organization                :string
+#  othered                     :string(10000)
+#  othersocialmedia            :string
+#  pronouns                    :string(400)
+#  pseudonym                   :string
+#  pseudonym_sort_by           :string
+#  pseudonym_sort_by_confirmed :boolean          default(FALSE)
+#  published_name              :string
+#  published_name_sort_by      :string
+#  reddit                      :string
+#  registered                  :boolean          default(FALSE), not null
+#  registration_number         :string
+#  registration_type           :string
+#  remember_created_at         :datetime
+#  reset_password_sent_at      :datetime
+#  reset_password_token        :string
+#  romantic_sexual_orientation :string
+#  sign_in_count               :integer          default(0), not null
+#  tiktok                      :string
+#  timezone                    :string(500)
+#  twelve_hour                 :boolean          default(TRUE)
+#  twitch                      :string
+#  twitter                     :string
+#  unconfirmed_email           :string
+#  unlock_token                :string
+#  website                     :string
+#  willing_to_moderate         :boolean          default(FALSE)
+#  year_of_birth               :integer
+#  youtube                     :string
+#  created_at                  :datetime         not null
+#  updated_at                  :datetime         not null
+#  reg_id                      :string
+#
+# Indexes
+#
+#  index_people_on_bio                   (bio) USING gin
+#  index_people_on_confirmation_token    (confirmation_token) UNIQUE
+#  index_people_on_name                  (name) USING gin
+#  index_people_on_pseudonym             (pseudonym) USING gin
+#  index_people_on_published_name        (published_name) USING gin
+#  index_people_on_reset_password_token  (reset_password_token) UNIQUE
+#  index_people_on_unlock_token          (unlock_token) UNIQUE
+#
 class PersonSerializer #< ActiveModel::Serializer
   include JSONAPI::Serializer
   include ::Plano::Serializer

--- a/app/serializers/publication_date_serializer.rb
+++ b/app/serializers/publication_date_serializer.rb
@@ -1,3 +1,20 @@
+# == Schema Information
+#
+# Table name: publication_dates
+#
+#  id                  :uuid             not null, primary key
+#  dropped_assignments :integer          default(0)
+#  dropped_sessions    :integer          default(0)
+#  lock_version        :integer          default(0)
+#  new_assignments     :integer          default(0)
+#  new_sessions        :integer          default(0)
+#  sent_external       :boolean          default(FALSE), not null
+#  timestamp           :datetime
+#  updated_assignments :integer          default(0)
+#  updated_sessions    :integer          default(0)
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#
 class PublicationDateSerializer
   include JSONAPI::Serializer
 

--- a/app/serializers/published_session_serializer.rb
+++ b/app/serializers/published_session_serializer.rb
@@ -1,3 +1,34 @@
+# == Schema Information
+#
+# Table name: published_sessions
+#
+#  audience_size        :integer
+#  description          :text
+#  duration             :integer
+#  environment          :enum             default("unknown")
+#  integrations         :jsonb            not null
+#  is_break             :boolean          default(FALSE)
+#  lock_version         :integer          default(0)
+#  minors_participation :jsonb
+#  participant_notes    :text
+#  pub_reference_number :integer
+#  recorded             :boolean          default(FALSE), not null
+#  require_signup       :boolean          default(FALSE)
+#  start_time           :datetime
+#  streamed             :boolean          default(FALSE), not null
+#  title                :string
+#  visibility           :enum             default("is_public")
+#  waiting_list_size    :integer          default(0)
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#  format_id            :uuid
+#  room_id              :uuid
+#  session_id           :uuid             not null, primary key
+#
+# Indexes
+#
+#  index_published_sessions_on_format_id  (format_id)
+#
 class PublishedSessionSerializer
   include JSONAPI::Serializer
 

--- a/app/serializers/room_serializer.rb
+++ b/app/serializers/room_serializer.rb
@@ -1,3 +1,35 @@
+# == Schema Information
+#
+# Table name: rooms
+#
+#  id                :uuid             not null, primary key
+#  area_of_space     :decimal(, )
+#  capacity          :integer
+#  comment           :text
+#  floor             :string
+#  height            :decimal(, )
+#  integrations      :jsonb            not null
+#  is_virtual        :boolean          default(FALSE)
+#  length            :decimal(, )
+#  lock_version      :integer          default(0)
+#  name              :string(490)      not null
+#  open_for_schedule :boolean          default(TRUE)
+#  purpose           :string
+#  sort_order        :integer
+#  width             :decimal(, )
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  room_set_id       :uuid
+#  venue_id          :uuid
+#
+# Indexes
+#
+#  index_rooms_on_room_set_id  (room_set_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (room_set_id => room_sets.id)
+#
 class RoomSerializer
   include JSONAPI::Serializer
 

--- a/app/serializers/room_set_serializer.rb
+++ b/app/serializers/room_set_serializer.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: room_sets
+#
+#  id           :uuid             not null, primary key
+#  description  :string
+#  lock_version :integer          default(0)
+#  name         :string
+#  sort_order   :integer
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
 class RoomSetSerializer
   include JSONAPI::Serializer
 

--- a/app/serializers/schedule_snapshot_serializer.rb
+++ b/app/serializers/schedule_snapshot_serializer.rb
@@ -1,3 +1,21 @@
+# == Schema Information
+#
+# Table name: schedule_snapshots
+#
+#  id           :uuid             not null, primary key
+#  completed_at :datetime
+#  created_by   :string
+#  label        :string
+#  lock_version :integer
+#  started_at   :datetime
+#  status       :enum             default("not_set")
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
+# Indexes
+#
+#  index_schedule_snapshots_on_label  (label) UNIQUE
+#
 class ScheduleSnapshotSerializer
   include JSONAPI::Serializer
 

--- a/app/serializers/schedule_workflow_serializer.rb
+++ b/app/serializers/schedule_workflow_serializer.rb
@@ -1,3 +1,20 @@
+# == Schema Information
+#
+# Table name: schedule_workflows
+#
+#  id                   :uuid             not null, primary key
+#  created_by           :string
+#  lock_version         :integer
+#  set_at               :datetime
+#  state                :enum             default("not_set")
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#  schedule_snapshot_id :uuid
+#
+# Indexes
+#
+#  index_schedule_workflows_on_schedule_snapshot_id  (schedule_snapshot_id) UNIQUE
+#
 class ScheduleWorkflowSerializer
   include JSONAPI::Serializer
 

--- a/app/serializers/session_area_serializer.rb
+++ b/app/serializers/session_area_serializer.rb
@@ -1,3 +1,19 @@
+# == Schema Information
+#
+# Table name: session_areas
+#
+#  id           :uuid             not null, primary key
+#  lock_version :integer
+#  primary      :boolean
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  area_id      :uuid
+#  session_id   :uuid
+#
+# Indexes
+#
+#  index_session_areas_on_session_id_and_area_id  (session_id,area_id) UNIQUE
+#
 class SessionAreaSerializer
   include JSONAPI::Serializer
 

--- a/app/serializers/session_assignment_serializer.rb
+++ b/app/serializers/session_assignment_serializer.rb
@@ -1,3 +1,30 @@
+# == Schema Information
+#
+# Table name: session_assignments
+#
+#  id                              :uuid             not null, primary key
+#  interest_notes                  :text
+#  interest_ranking                :integer
+#  interest_role                   :enum             default("no_preference")
+#  interested                      :boolean          default(FALSE)
+#  lock_version                    :integer          default(0)
+#  planner_notes                   :text
+#  sort_order                      :integer
+#  state                           :string
+#  visibility                      :enum             default("is_public")
+#  created_at                      :datetime         not null
+#  updated_at                      :datetime         not null
+#  person_id                       :uuid             not null
+#  session_assignment_role_type_id :uuid
+#  session_id                      :uuid             not null
+#
+# Indexes
+#
+#  index_session_assignments_on_interest_role                    (interest_role)
+#  index_session_assignments_on_session_assignment_role_type_id  (session_assignment_role_type_id)
+#  pia_person_index                                              (person_id)
+#  pis_prog_item_id_index                                        (session_id)
+#
 class SessionAssignmentSerializer
   include JSONAPI::Serializer
 

--- a/app/serializers/session_limit_serializer.rb
+++ b/app/serializers/session_limit_serializer.rb
@@ -1,3 +1,20 @@
+# == Schema Information
+#
+# Table name: session_limits
+#
+#  id           :uuid             not null, primary key
+#  day          :date
+#  lock_version :integer
+#  max_sessions :integer
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  person_id    :uuid
+#
+# Indexes
+#
+#  index_session_limits_on_person_id          (person_id)
+#  index_session_limits_on_person_id_and_day  (person_id,day) UNIQUE
+#
 class SessionLimitSerializer
   include JSONAPI::Serializer
 

--- a/app/serializers/session_serializer.rb
+++ b/app/serializers/session_serializer.rb
@@ -1,3 +1,57 @@
+# == Schema Information
+#
+# Table name: sessions
+#
+#  id                        :uuid             not null, primary key
+#  audience_size             :integer
+#  description               :text
+#  duration                  :integer
+#  environment               :enum             default("unknown")
+#  instructions_for_interest :text
+#  interest_opened_at        :datetime
+#  interest_opened_by        :string
+#  is_break                  :boolean          default(FALSE)
+#  item_notes                :text
+#  lock_version              :integer          default(0)
+#  maximum_people            :integer
+#  minimum_people            :integer
+#  minors_participation      :jsonb
+#  open_for_interest         :boolean          default(FALSE)
+#  participant_notes         :text
+#  proofed                   :boolean          default(FALSE), not null
+#  pub_reference_number      :integer
+#  publish                   :boolean          default(FALSE), not null
+#  recorded                  :boolean          default(FALSE), not null
+#  require_signup            :boolean          default(FALSE)
+#  room_notes                :text
+#  start_time                :datetime
+#  status                    :enum             default("draft")
+#  streamed                  :boolean          default(FALSE), not null
+#  tech_notes                :text
+#  title                     :string(256)
+#  updated_by                :string
+#  visibility                :enum             default("is_public")
+#  waiting_list_size         :integer          default(0)
+#  created_at                :datetime         not null
+#  updated_at                :datetime         not null
+#  age_restriction_id        :uuid
+#  format_id                 :uuid
+#  room_id                   :uuid
+#  room_set_id               :uuid
+#
+# Indexes
+#
+#  index_sessions_on_description                (description) USING gin
+#  index_sessions_on_instructions_for_interest  (instructions_for_interest) USING gin
+#  index_sessions_on_interest_opened_by         (interest_opened_by) USING gin
+#  index_sessions_on_item_notes                 (item_notes) USING gin
+#  index_sessions_on_participant_notes          (participant_notes) USING gin
+#  index_sessions_on_room_id                    (room_id)
+#  index_sessions_on_room_notes                 (room_notes) USING gin
+#  index_sessions_on_tech_notes                 (tech_notes) USING gin
+#  index_sessions_on_title                      (title) USING gin
+#  index_sessions_on_updated_by                 (updated_by) USING gin
+#
 class SessionSerializer
   include JSONAPI::Serializer
 

--- a/app/serializers/survey/answer_serializer.rb
+++ b/app/serializers/survey/answer_serializer.rb
@@ -1,3 +1,24 @@
+# == Schema Information
+#
+# Table name: survey_answers
+#
+#  id               :uuid             not null, primary key
+#  answer           :text
+#  default          :boolean          default(FALSE)
+#  lock_version     :integer          default(0)
+#  next_page_action :enum             default("next_page")
+#  other            :boolean          default(FALSE)
+#  sort_order       :integer
+#  value            :string
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  next_page_id     :uuid
+#  question_id      :uuid
+#
+# Indexes
+#
+#  index_survey_answers_on_next_page_action  (next_page_action)
+#
 class Survey::AnswerSerializer
   include JSONAPI::Serializer
 

--- a/app/serializers/survey/page_serializer.rb
+++ b/app/serializers/survey/page_serializer.rb
@@ -1,3 +1,25 @@
+# == Schema Information
+#
+# Table name: survey_pages
+#
+#  id               :uuid             not null, primary key
+#  next_page_action :enum             default("next_page")
+#  sort_order       :integer
+#  title            :string
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  next_page_id     :uuid
+#  survey_id        :uuid
+#
+# Indexes
+#
+#  index_survey_pages_on_next_page_action  (next_page_action)
+#  index_survey_pages_on_survey_id         (survey_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (survey_id => surveys.id)
+#
 class Survey::PageSerializer
   include JSONAPI::Serializer
 

--- a/app/serializers/survey/question_serializer.rb
+++ b/app/serializers/survey/question_serializer.rb
@@ -1,3 +1,33 @@
+# == Schema Information
+#
+# Table name: survey_questions
+#
+#  id            :uuid             not null, primary key
+#  branching     :boolean          default(FALSE)
+#  deleted_at    :datetime
+#  horizontal    :boolean          default(FALSE)
+#  linked_field  :text
+#  lock_version  :integer          default(0)
+#  mandatory     :boolean          default(FALSE)
+#  private       :boolean          default(FALSE)
+#  question      :text
+#  question_type :string           default("textfield")
+#  randomize     :boolean          default(FALSE)
+#  regex         :string
+#  sort_order    :integer
+#  text_size     :integer
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  page_id       :uuid
+#
+# Indexes
+#
+#  index_survey_questions_on_page_id  (page_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (page_id => survey_pages.id)
+#
 class Survey::QuestionSerializer
   include JSONAPI::Serializer
 

--- a/app/serializers/survey/response_serializer.rb
+++ b/app/serializers/survey/response_serializer.rb
@@ -1,3 +1,25 @@
+# == Schema Information
+#
+# Table name: survey_responses
+#
+#  id               :uuid             not null, primary key
+#  lock_version     :integer          default(0)
+#  response         :jsonb
+#  response_as_text :text
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  question_id      :uuid             not null
+#  submission_id    :uuid             not null
+#
+# Indexes
+#
+#  index_survey_responses_on_submission_id  (submission_id)
+#  survey_resp_question_idx                 (question_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (submission_id => survey_submissions.id)
+#
 class Survey::ResponseSerializer
   include JSONAPI::Serializer
   include Plano::AccessHelper

--- a/app/serializers/survey/submission_serializer.rb
+++ b/app/serializers/survey/submission_serializer.rb
@@ -1,3 +1,27 @@
+# == Schema Information
+#
+# Table name: survey_submissions
+#
+#  id               :uuid             not null, primary key
+#  lock_version     :integer          default(0)
+#  name             :string
+#  submission_state :enum             default("draft")
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  person_id        :uuid             not null
+#  survey_id        :uuid             not null
+#
+# Indexes
+#
+#  index_survey_submissions_on_person_id         (person_id)
+#  index_survey_submissions_on_submission_state  (submission_state)
+#  index_survey_submissions_on_survey_id         (survey_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (person_id => people.id)
+#  fk_rails_...  (survey_id => surveys.id)
+#
 class Survey::SubmissionSerializer
   include JSONAPI::Serializer
 

--- a/app/serializers/survey_serializer.rb
+++ b/app/serializers/survey_serializer.rb
@@ -1,3 +1,33 @@
+# == Schema Information
+#
+# Table name: surveys
+#
+#  id                        :uuid             not null, primary key
+#  allow_submission_edits    :boolean          default(TRUE)
+#  authenticate_msg          :text
+#  branded                   :boolean          default(TRUE)
+#  declined_msg              :text
+#  description               :text
+#  lock_version              :integer          default(0)
+#  mandatory_star            :boolean          default(TRUE)
+#  name                      :string
+#  numbered_questions        :boolean          default(FALSE)
+#  public                    :boolean
+#  published_on              :datetime
+#  submit_string             :string           default("Save")
+#  thank_you                 :text
+#  transition_accept_status  :enum
+#  transition_decline_status :enum
+#  unassigned                :boolean          default(FALSE)
+#  unique_submission         :boolean          default(TRUE)
+#  use_captcha               :boolean          default(FALSE)
+#  welcome                   :text
+#  created_at                :datetime         not null
+#  updated_at                :datetime         not null
+#  created_by_id             :uuid
+#  published_by_id           :uuid
+#  updated_by_id             :uuid
+#
 class SurveySerializer
   include JSONAPI::Serializer
 

--- a/app/serializers/tag_context_serializer.rb
+++ b/app/serializers/tag_context_serializer.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: tag_contexts
+#
+#  id           :uuid             not null, primary key
+#  lock_version :integer          default(0)
+#  name         :string
+#  publish      :boolean          default(TRUE)
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
 class TagContextSerializer
   include JSONAPI::Serializer
 

--- a/app/serializers/venue_serializer.rb
+++ b/app/serializers/venue_serializer.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: venues
+#
+#  id           :uuid             not null, primary key
+#  address      :string
+#  lock_version :integer          default(0)
+#  name         :string
+#  sort_order   :integer
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
 class VenueSerializer
   include JSONAPI::Serializer
 

--- a/lib/tasks/auto_annotate_models.rake
+++ b/lib/tasks/auto_annotate_models.rake
@@ -1,0 +1,59 @@
+# NOTE: only doing this in development as some production environments (Heroku)
+# NOTE: are sensitive to local FS writes, and besides -- it's just not proper
+# NOTE: to have a dev-mode tool do its thing in production.
+if Rails.env.development?
+  require 'annotate'
+  task :set_annotation_options do
+    # You can override any of these by setting an environment variable of the
+    # same name.
+    Annotate.set_defaults(
+      'active_admin'                => 'false',
+      'additional_file_patterns'    => [],
+      'routes'                      => 'false',
+      'models'                      => 'true',
+      'position_in_routes'          => 'before',
+      'position_in_class'           => 'before',
+      'position_in_test'            => 'before',
+      'position_in_fixture'         => 'before',
+      'position_in_factory'         => 'before',
+      'position_in_serializer'      => 'before',
+      'show_foreign_keys'           => 'true',
+      'show_complete_foreign_keys'  => 'false',
+      'show_indexes'                => 'true',
+      'simple_indexes'              => 'false',
+      'model_dir'                   => 'app/models',
+      'root_dir'                    => '',
+      'include_version'             => 'false',
+      'require'                     => '',
+      'exclude_tests'               => 'false',
+      'exclude_fixtures'            => 'false',
+      'exclude_factories'           => 'false',
+      'exclude_serializers'         => 'false',
+      'exclude_scaffolds'           => 'true',
+      'exclude_controllers'         => 'true',
+      'exclude_helpers'             => 'true',
+      'exclude_sti_subclasses'      => 'false',
+      'ignore_model_sub_dir'        => 'false',
+      'ignore_columns'              => nil,
+      'ignore_routes'               => nil,
+      'ignore_unknown_models'       => 'false',
+      'hide_limit_column_types'     => 'integer,bigint,boolean',
+      'hide_default_column_types'   => 'json,jsonb,hstore',
+      'skip_on_db_migrate'          => 'false',
+      'format_bare'                 => 'true',
+      'format_rdoc'                 => 'false',
+      'format_yard'                 => 'false',
+      'format_markdown'             => 'false',
+      'sort'                        => 'false',
+      'force'                       => 'false',
+      'frozen'                      => 'false',
+      'classified_sort'             => 'true',
+      'trace'                       => 'false',
+      'wrapper_open'                => nil,
+      'wrapper_close'               => nil,
+      'with_comment'                => 'true'
+    )
+  end
+
+  Annotate.load_tasks
+end

--- a/spec/factories/page_contents.rb
+++ b/spec/factories/page_contents.rb
@@ -1,3 +1,18 @@
+# == Schema Information
+#
+# Table name: page_contents
+#
+#  id           :uuid             not null, primary key
+#  html         :text             not null
+#  lock_version :integer
+#  name         :string           not null
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
+# Indexes
+#
+#  unique_page_content  (name) UNIQUE
+#
 FactoryBot.define do
   factory :page_content do
     sequence(:name) { |n| "page #{n}" }

--- a/spec/factories/session_assignment_role_type.rb
+++ b/spec/factories/session_assignment_role_type.rb
@@ -1,3 +1,16 @@
+# == Schema Information
+#
+# Table name: session_assignment_role_type
+#
+#  id                 :uuid             not null, primary key
+#  default_visibility :enum             default("is_public")
+#  lock_version       :integer          default(0)
+#  name               :string(100)      not null
+#  role_type          :enum
+#  sort_order         :integer
+#  created_at         :datetime
+#  updated_at         :datetime
+#
 FactoryBot.define do
     factory :session_assignment_role_type do
         sequence :id

--- a/spec/models/integration_spec.rb
+++ b/spec/models/integration_spec.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: integrations
+#
+#  id           :uuid             not null, primary key
+#  config       :jsonb            not null
+#  lock_version :integer          default(0)
+#  name         :string
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
 require 'rails_helper'
 
 RSpec.describe Integration, type: :model do

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -1,3 +1,99 @@
+# == Schema Information
+#
+# Table name: people
+#
+#  id                          :uuid             not null, primary key
+#  accommodations              :string(10000)
+#  age_at_convention           :string
+#  attendance_type             :string(200)
+#  availability_notes          :string
+#  bio                         :text
+#  black_diaspora              :string(10000)
+#  can_photo                   :enum             default("no")
+#  can_photo_exceptions        :string(10000)
+#  can_record                  :enum             default("no")
+#  can_record_exceptions       :string(10000)
+#  can_share                   :boolean          default(FALSE), not null
+#  can_stream                  :enum             default("no")
+#  can_stream_exceptions       :string(10000)
+#  comments                    :text
+#  con_state                   :enum             default("not_set")
+#  confirmation_sent_at        :datetime
+#  confirmation_token          :string
+#  confirmed_at                :datetime
+#  current_sign_in_at          :datetime
+#  current_sign_in_ip          :inet
+#  date_reg_synced             :datetime
+#  demographic_categories      :string
+#  do_not_assign_with          :string(10000)
+#  encrypted_password          :string           default(""), not null
+#  ethnicity                   :string(400)
+#  facebook                    :string
+#  failed_attempts             :integer          default(0), not null
+#  flickr                      :string
+#  gender                      :string(400)
+#  indigenous                  :string(10000)
+#  instagram                   :string
+#  integrations                :jsonb            not null
+#  is_local                    :boolean          default(FALSE)
+#  job_title                   :string
+#  language                    :string(5)        default("")
+#  languages_fluent_in         :string(10000)
+#  last_sign_in_at             :datetime
+#  last_sign_in_ip             :inet
+#  linkedin                    :string
+#  lock_version                :integer          default(0)
+#  locked_at                   :datetime
+#  moderation_experience       :string(10000)
+#  name                        :string           default("")
+#  name_sort_by                :string
+#  name_sort_by_confirmed      :boolean          default(FALSE)
+#  needs_accommodations        :boolean          default(FALSE)
+#  non_us_centric_perspectives :string(10000)
+#  opted_in                    :boolean          default(FALSE), not null
+#  organization                :string
+#  othered                     :string(10000)
+#  othersocialmedia            :string
+#  pronouns                    :string(400)
+#  pseudonym                   :string
+#  pseudonym_sort_by           :string
+#  pseudonym_sort_by_confirmed :boolean          default(FALSE)
+#  published_name              :string
+#  published_name_sort_by      :string
+#  reddit                      :string
+#  registered                  :boolean          default(FALSE), not null
+#  registration_number         :string
+#  registration_type           :string
+#  remember_created_at         :datetime
+#  reset_password_sent_at      :datetime
+#  reset_password_token        :string
+#  romantic_sexual_orientation :string
+#  sign_in_count               :integer          default(0), not null
+#  tiktok                      :string
+#  timezone                    :string(500)
+#  twelve_hour                 :boolean          default(TRUE)
+#  twitch                      :string
+#  twitter                     :string
+#  unconfirmed_email           :string
+#  unlock_token                :string
+#  website                     :string
+#  willing_to_moderate         :boolean          default(FALSE)
+#  year_of_birth               :integer
+#  youtube                     :string
+#  created_at                  :datetime         not null
+#  updated_at                  :datetime         not null
+#  reg_id                      :string
+#
+# Indexes
+#
+#  index_people_on_bio                   (bio) USING gin
+#  index_people_on_confirmation_token    (confirmation_token) UNIQUE
+#  index_people_on_name                  (name) USING gin
+#  index_people_on_pseudonym             (pseudonym) USING gin
+#  index_people_on_published_name        (published_name) USING gin
+#  index_people_on_reset_password_token  (reset_password_token) UNIQUE
+#  index_people_on_unlock_token          (unlock_token) UNIQUE
+#
 require 'rails_helper'
 
 RSpec.describe Person, '#factories' do

--- a/spec/models/room_spec.rb
+++ b/spec/models/room_spec.rb
@@ -1,3 +1,35 @@
+# == Schema Information
+#
+# Table name: rooms
+#
+#  id                :uuid             not null, primary key
+#  area_of_space     :decimal(, )
+#  capacity          :integer
+#  comment           :text
+#  floor             :string
+#  height            :decimal(, )
+#  integrations      :jsonb            not null
+#  is_virtual        :boolean          default(FALSE)
+#  length            :decimal(, )
+#  lock_version      :integer          default(0)
+#  name              :string(490)      not null
+#  open_for_schedule :boolean          default(TRUE)
+#  purpose           :string
+#  sort_order        :integer
+#  width             :decimal(, )
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  room_set_id       :uuid
+#  venue_id          :uuid
+#
+# Indexes
+#
+#  index_rooms_on_room_set_id  (room_set_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (room_set_id => room_sets.id)
+#
 require 'rails_helper'
 
 RSpec.describe Room, "#factories"  do

--- a/spec/models/session_assignment_role_type_spec.rb
+++ b/spec/models/session_assignment_role_type_spec.rb
@@ -1,3 +1,16 @@
+# == Schema Information
+#
+# Table name: session_assignment_role_type
+#
+#  id                 :uuid             not null, primary key
+#  default_visibility :enum             default("is_public")
+#  lock_version       :integer          default(0)
+#  name               :string(100)      not null
+#  role_type          :enum
+#  sort_order         :integer
+#  created_at         :datetime
+#  updated_at         :datetime
+#
 require 'rails_helper'
 
 RSpec.describe SessionAssignmentRoleType do

--- a/spec/models/session_spec.rb
+++ b/spec/models/session_spec.rb
@@ -1,3 +1,57 @@
+# == Schema Information
+#
+# Table name: sessions
+#
+#  id                        :uuid             not null, primary key
+#  audience_size             :integer
+#  description               :text
+#  duration                  :integer
+#  environment               :enum             default("unknown")
+#  instructions_for_interest :text
+#  interest_opened_at        :datetime
+#  interest_opened_by        :string
+#  is_break                  :boolean          default(FALSE)
+#  item_notes                :text
+#  lock_version              :integer          default(0)
+#  maximum_people            :integer
+#  minimum_people            :integer
+#  minors_participation      :jsonb
+#  open_for_interest         :boolean          default(FALSE)
+#  participant_notes         :text
+#  proofed                   :boolean          default(FALSE), not null
+#  pub_reference_number      :integer
+#  publish                   :boolean          default(FALSE), not null
+#  recorded                  :boolean          default(FALSE), not null
+#  require_signup            :boolean          default(FALSE)
+#  room_notes                :text
+#  start_time                :datetime
+#  status                    :enum             default("draft")
+#  streamed                  :boolean          default(FALSE), not null
+#  tech_notes                :text
+#  title                     :string(256)
+#  updated_by                :string
+#  visibility                :enum             default("is_public")
+#  waiting_list_size         :integer          default(0)
+#  created_at                :datetime         not null
+#  updated_at                :datetime         not null
+#  age_restriction_id        :uuid
+#  format_id                 :uuid
+#  room_id                   :uuid
+#  room_set_id               :uuid
+#
+# Indexes
+#
+#  index_sessions_on_description                (description) USING gin
+#  index_sessions_on_instructions_for_interest  (instructions_for_interest) USING gin
+#  index_sessions_on_interest_opened_by         (interest_opened_by) USING gin
+#  index_sessions_on_item_notes                 (item_notes) USING gin
+#  index_sessions_on_participant_notes          (participant_notes) USING gin
+#  index_sessions_on_room_id                    (room_id)
+#  index_sessions_on_room_notes                 (room_notes) USING gin
+#  index_sessions_on_tech_notes                 (tech_notes) USING gin
+#  index_sessions_on_title                      (title) USING gin
+#  index_sessions_on_updated_by                 (updated_by) USING gin
+#
 require 'rails_helper'
 
 RSpec.describe Session, "#factories" do

--- a/spec/models/survey_spec.rb
+++ b/spec/models/survey_spec.rb
@@ -1,3 +1,33 @@
+# == Schema Information
+#
+# Table name: surveys
+#
+#  id                        :uuid             not null, primary key
+#  allow_submission_edits    :boolean          default(TRUE)
+#  authenticate_msg          :text
+#  branded                   :boolean          default(TRUE)
+#  declined_msg              :text
+#  description               :text
+#  lock_version              :integer          default(0)
+#  mandatory_star            :boolean          default(TRUE)
+#  name                      :string
+#  numbered_questions        :boolean          default(FALSE)
+#  public                    :boolean
+#  published_on              :datetime
+#  submit_string             :string           default("Save")
+#  thank_you                 :text
+#  transition_accept_status  :enum
+#  transition_decline_status :enum
+#  unassigned                :boolean          default(FALSE)
+#  unique_submission         :boolean          default(TRUE)
+#  use_captcha               :boolean          default(FALSE)
+#  welcome                   :text
+#  created_at                :datetime         not null
+#  updated_at                :datetime         not null
+#  created_by_id             :uuid
+#  published_by_id           :uuid
+#  updated_by_id             :uuid
+#
 require 'rails_helper'
 
 RSpec.describe Survey  do

--- a/spec/models/venue_spec.rb
+++ b/spec/models/venue_spec.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: venues
+#
+#  id           :uuid             not null, primary key
+#  address      :string
+#  lock_version :integer          default(0)
+#  name         :string
+#  sort_order   :integer
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
 require 'rails_helper'
 
 RSpec.describe Venue, "#factories"  do

--- a/test/factories/agreements.rb
+++ b/test/factories/agreements.rb
@@ -1,3 +1,25 @@
+# == Schema Information
+#
+# Table name: agreements
+#
+#  id             :uuid             not null, primary key
+#  agreement_type :string
+#  description    :string(10000)
+#  lock_version   :integer          default(0)
+#  target         :enum
+#  terms          :text
+#  title          :string
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  created_by_id  :uuid             not null
+#  updated_by_id  :uuid             not null
+#
+# Indexes
+#
+#  index_agreements_on_created_by_id  (created_by_id)
+#  index_agreements_on_target         (target)
+#  index_agreements_on_updated_by_id  (updated_by_id)
+#
 FactoryBot.define do
   factory :agreement do
     

--- a/test/factories/areas.rb
+++ b/test/factories/areas.rb
@@ -1,3 +1,18 @@
+# == Schema Information
+#
+# Table name: areas
+#
+#  id           :uuid             not null, primary key
+#  lock_version :integer          default(0)
+#  name         :string
+#  sort_order   :integer
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
+# Indexes
+#
+#  index_areas_on_name  (name) UNIQUE
+#
 FactoryBot.define do
   factory :area do
     

--- a/test/factories/availabilities.rb
+++ b/test/factories/availabilities.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: availabilities
+#
+#  id           :uuid             not null, primary key
+#  end_time     :datetime
+#  lock_version :integer
+#  start_time   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  person_id    :uuid
+#
 FactoryBot.define do
   factory :availability do
     

--- a/test/factories/exclusions.rb
+++ b/test/factories/exclusions.rb
@@ -1,3 +1,13 @@
+# == Schema Information
+#
+# Table name: exclusions
+#
+#  id           :uuid             not null, primary key
+#  lock_version :integer
+#  title        :string(800)      not null
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
 FactoryBot.define do
   factory :exclusion do
     

--- a/test/factories/ignored_conflicts.rb
+++ b/test/factories/ignored_conflicts.rb
@@ -1,3 +1,17 @@
+# == Schema Information
+#
+# Table name: ignored_conflicts
+#
+#  id            :uuid             not null, primary key
+#  conflict_type :string
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  conflict_id   :string(2048)
+#
+# Indexes
+#
+#  index_ignored_conflicts_on_conflict_id_and_conflict_type  (conflict_id,conflict_type) UNIQUE
+#
 FactoryBot.define do
   factory :ignored_conflict do
     

--- a/test/factories/magic_links.rb
+++ b/test/factories/magic_links.rb
@@ -1,3 +1,20 @@
+# == Schema Information
+#
+# Table name: magic_links
+#
+#  id           :uuid             not null, primary key
+#  expires_at   :datetime         not null
+#  lock_version :integer          default(0)
+#  token        :string           not null
+#  url          :string(10000)
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  person_id    :uuid             not null
+#
+# Indexes
+#
+#  index_magic_links_on_person_id  (person_id)
+#
 FactoryBot.define do
   factory :magic_link do
     

--- a/test/factories/old_passwords.rb
+++ b/test/factories/old_passwords.rb
@@ -1,3 +1,18 @@
+# == Schema Information
+#
+# Table name: old_passwords
+#
+#  id                       :bigint           not null, primary key
+#  encrypted_password       :string           not null
+#  password_archivable_type :string           not null
+#  password_salt            :string
+#  created_at               :datetime
+#  password_archivable_id   :integer          not null
+#
+# Indexes
+#
+#  index_password_archivable  (password_archivable_type,password_archivable_id)
+#
 FactoryBot.define do
   factory :old_password do
     

--- a/test/factories/person_agreements.rb
+++ b/test/factories/person_agreements.rb
@@ -1,3 +1,22 @@
+# == Schema Information
+#
+# Table name: person_agreements
+#
+#  id           :uuid             not null, primary key
+#  agreed_on    :datetime         not null
+#  lock_version :integer          default(0)
+#  signed       :boolean          default(FALSE)
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  agreement_id :uuid             not null
+#  person_id    :uuid             not null
+#
+# Indexes
+#
+#  index_person_agreements_on_agreement_id                (agreement_id)
+#  index_person_agreements_on_person_id                   (person_id)
+#  index_person_agreements_on_person_id_and_agreement_id  (person_id,agreement_id) UNIQUE
+#
 FactoryBot.define do
   factory :person_agreement do
     

--- a/test/factories/person_exclusions.rb
+++ b/test/factories/person_exclusions.rb
@@ -1,3 +1,19 @@
+# == Schema Information
+#
+# Table name: person_exclusions
+#
+#  id           :uuid             not null, primary key
+#  lock_version :integer
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  exclusion_id :uuid
+#  person_id    :uuid
+#
+# Indexes
+#
+#  index_person_exclusions_on_person_id                   (person_id)
+#  index_person_exclusions_on_person_id_and_exclusion_id  (person_id,exclusion_id) UNIQUE
+#
 FactoryBot.define do
   factory :person_exclusion do
     

--- a/test/factories/publish_snapshots.rb
+++ b/test/factories/publish_snapshots.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: publish_snapshots
+#
+#  id                  :uuid             not null, primary key
+#  label               :string
+#  snapshot            :jsonb
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  publication_date_id :uuid
+#
 FactoryBot.define do
   factory :publish_snapshot do
     

--- a/test/factories/registration_sync_data.rb
+++ b/test/factories/registration_sync_data.rb
@@ -1,3 +1,26 @@
+# == Schema Information
+#
+# Table name: registration_sync_data
+#
+#  id                  :uuid             not null, primary key
+#  alternative_email   :string
+#  email               :string
+#  lock_version        :integer
+#  name                :string
+#  preferred_name      :string
+#  raw_info            :jsonb            not null
+#  registration_number :string
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  reg_id              :string
+#
+# Indexes
+#
+#  index_registration_sync_data_on_email                (email) USING gin
+#  index_registration_sync_data_on_name                 (name) USING gin
+#  index_registration_sync_data_on_reg_id               (reg_id)
+#  index_registration_sync_data_on_registration_number  (registration_number)
+#
 FactoryBot.define do
   factory :registration_sync_datum do
     

--- a/test/factories/room_sets.rb
+++ b/test/factories/room_sets.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: room_sets
+#
+#  id           :uuid             not null, primary key
+#  description  :string
+#  lock_version :integer          default(0)
+#  name         :string
+#  sort_order   :integer
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
 FactoryBot.define do
   factory :room_set do
     name { "MyString" }

--- a/test/factories/session_areas.rb
+++ b/test/factories/session_areas.rb
@@ -1,3 +1,19 @@
+# == Schema Information
+#
+# Table name: session_areas
+#
+#  id           :uuid             not null, primary key
+#  lock_version :integer
+#  primary      :boolean
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  area_id      :uuid
+#  session_id   :uuid
+#
+# Indexes
+#
+#  index_session_areas_on_session_id_and_area_id  (session_id,area_id) UNIQUE
+#
 FactoryBot.define do
   factory :session_area do
     

--- a/test/factories/session_limits.rb
+++ b/test/factories/session_limits.rb
@@ -1,3 +1,20 @@
+# == Schema Information
+#
+# Table name: session_limits
+#
+#  id           :uuid             not null, primary key
+#  day          :date
+#  lock_version :integer
+#  max_sessions :integer
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  person_id    :uuid
+#
+# Indexes
+#
+#  index_session_limits_on_person_id          (person_id)
+#  index_session_limits_on_person_id_and_day  (person_id,day) UNIQUE
+#
 FactoryBot.define do
   factory :session_limit do
     

--- a/test/factories/survey/submissions.rb
+++ b/test/factories/survey/submissions.rb
@@ -1,3 +1,27 @@
+# == Schema Information
+#
+# Table name: survey_submissions
+#
+#  id               :uuid             not null, primary key
+#  lock_version     :integer          default(0)
+#  name             :string
+#  submission_state :enum             default("draft")
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  person_id        :uuid             not null
+#  survey_id        :uuid             not null
+#
+# Indexes
+#
+#  index_survey_submissions_on_person_id         (person_id)
+#  index_survey_submissions_on_submission_state  (submission_state)
+#  index_survey_submissions_on_survey_id         (survey_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (person_id => people.id)
+#  fk_rails_...  (survey_id => surveys.id)
+#
 FactoryBot.define do
   factory :survey_submission, class: 'Survey::Submission' do
     

--- a/test/models/agreement_test.rb
+++ b/test/models/agreement_test.rb
@@ -1,3 +1,25 @@
+# == Schema Information
+#
+# Table name: agreements
+#
+#  id             :uuid             not null, primary key
+#  agreement_type :string
+#  description    :string(10000)
+#  lock_version   :integer          default(0)
+#  target         :enum
+#  terms          :text
+#  title          :string
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  created_by_id  :uuid             not null
+#  updated_by_id  :uuid             not null
+#
+# Indexes
+#
+#  index_agreements_on_created_by_id  (created_by_id)
+#  index_agreements_on_target         (target)
+#  index_agreements_on_updated_by_id  (updated_by_id)
+#
 require 'test_helper'
 
 class AgreementTest < ActiveSupport::TestCase

--- a/test/models/area_test.rb
+++ b/test/models/area_test.rb
@@ -1,3 +1,18 @@
+# == Schema Information
+#
+# Table name: areas
+#
+#  id           :uuid             not null, primary key
+#  lock_version :integer          default(0)
+#  name         :string
+#  sort_order   :integer
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
+# Indexes
+#
+#  index_areas_on_name  (name) UNIQUE
+#
 require 'test_helper'
 
 class AreaTest < ActiveSupport::TestCase

--- a/test/models/availability_test.rb
+++ b/test/models/availability_test.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: availabilities
+#
+#  id           :uuid             not null, primary key
+#  end_time     :datetime
+#  lock_version :integer
+#  start_time   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  person_id    :uuid
+#
 require "test_helper"
 
 class AvailabilityTest < ActiveSupport::TestCase

--- a/test/models/exclusion_test.rb
+++ b/test/models/exclusion_test.rb
@@ -1,3 +1,13 @@
+# == Schema Information
+#
+# Table name: exclusions
+#
+#  id           :uuid             not null, primary key
+#  lock_version :integer
+#  title        :string(800)      not null
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
 require "test_helper"
 
 class ExclusionTest < ActiveSupport::TestCase

--- a/test/models/ignored_conflict_test.rb
+++ b/test/models/ignored_conflict_test.rb
@@ -1,3 +1,17 @@
+# == Schema Information
+#
+# Table name: ignored_conflicts
+#
+#  id            :uuid             not null, primary key
+#  conflict_type :string
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  conflict_id   :string(2048)
+#
+# Indexes
+#
+#  index_ignored_conflicts_on_conflict_id_and_conflict_type  (conflict_id,conflict_type) UNIQUE
+#
 require "test_helper"
 
 class IgnoredConflictTest < ActiveSupport::TestCase

--- a/test/models/magic_link_test.rb
+++ b/test/models/magic_link_test.rb
@@ -1,3 +1,20 @@
+# == Schema Information
+#
+# Table name: magic_links
+#
+#  id           :uuid             not null, primary key
+#  expires_at   :datetime         not null
+#  lock_version :integer          default(0)
+#  token        :string           not null
+#  url          :string(10000)
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  person_id    :uuid             not null
+#
+# Indexes
+#
+#  index_magic_links_on_person_id  (person_id)
+#
 require 'test_helper'
 
 class MagicLinkTest < ActiveSupport::TestCase

--- a/test/models/old_password_test.rb
+++ b/test/models/old_password_test.rb
@@ -1,3 +1,18 @@
+# == Schema Information
+#
+# Table name: old_passwords
+#
+#  id                       :bigint           not null, primary key
+#  encrypted_password       :string           not null
+#  password_archivable_type :string           not null
+#  password_salt            :string
+#  created_at               :datetime
+#  password_archivable_id   :integer          not null
+#
+# Indexes
+#
+#  index_password_archivable  (password_archivable_type,password_archivable_id)
+#
 require "test_helper"
 
 class OldPasswordTest < ActiveSupport::TestCase

--- a/test/models/page_content_test.rb
+++ b/test/models/page_content_test.rb
@@ -1,3 +1,18 @@
+# == Schema Information
+#
+# Table name: page_contents
+#
+#  id           :uuid             not null, primary key
+#  html         :text             not null
+#  lock_version :integer
+#  name         :string           not null
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
+# Indexes
+#
+#  unique_page_content  (name) UNIQUE
+#
 require "test_helper"
 
 class PageContentTest < ActiveSupport::TestCase

--- a/test/models/person_agreement_test.rb
+++ b/test/models/person_agreement_test.rb
@@ -1,3 +1,22 @@
+# == Schema Information
+#
+# Table name: person_agreements
+#
+#  id           :uuid             not null, primary key
+#  agreed_on    :datetime         not null
+#  lock_version :integer          default(0)
+#  signed       :boolean          default(FALSE)
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  agreement_id :uuid             not null
+#  person_id    :uuid             not null
+#
+# Indexes
+#
+#  index_person_agreements_on_agreement_id                (agreement_id)
+#  index_person_agreements_on_person_id                   (person_id)
+#  index_person_agreements_on_person_id_and_agreement_id  (person_id,agreement_id) UNIQUE
+#
 require 'test_helper'
 
 class PersonAgreementTest < ActiveSupport::TestCase

--- a/test/models/person_exclusion_test.rb
+++ b/test/models/person_exclusion_test.rb
@@ -1,3 +1,19 @@
+# == Schema Information
+#
+# Table name: person_exclusions
+#
+#  id           :uuid             not null, primary key
+#  lock_version :integer
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  exclusion_id :uuid
+#  person_id    :uuid
+#
+# Indexes
+#
+#  index_person_exclusions_on_person_id                   (person_id)
+#  index_person_exclusions_on_person_id_and_exclusion_id  (person_id,exclusion_id) UNIQUE
+#
 require "test_helper"
 
 class PersonExclusionTest < ActiveSupport::TestCase

--- a/test/models/publish_snapshot_test.rb
+++ b/test/models/publish_snapshot_test.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: publish_snapshots
+#
+#  id                  :uuid             not null, primary key
+#  label               :string
+#  snapshot            :jsonb
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  publication_date_id :uuid
+#
 require "test_helper"
 
 class PublishSnapshotTest < ActiveSupport::TestCase

--- a/test/models/registration_sync_datum_test.rb
+++ b/test/models/registration_sync_datum_test.rb
@@ -1,3 +1,26 @@
+# == Schema Information
+#
+# Table name: registration_sync_data
+#
+#  id                  :uuid             not null, primary key
+#  alternative_email   :string
+#  email               :string
+#  lock_version        :integer
+#  name                :string
+#  preferred_name      :string
+#  raw_info            :jsonb            not null
+#  registration_number :string
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  reg_id              :string
+#
+# Indexes
+#
+#  index_registration_sync_data_on_email                (email) USING gin
+#  index_registration_sync_data_on_name                 (name) USING gin
+#  index_registration_sync_data_on_reg_id               (reg_id)
+#  index_registration_sync_data_on_registration_number  (registration_number)
+#
 require "test_helper"
 
 class RegistrationSyncDatumTest < ActiveSupport::TestCase

--- a/test/models/room_set_test.rb
+++ b/test/models/room_set_test.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: room_sets
+#
+#  id           :uuid             not null, primary key
+#  description  :string
+#  lock_version :integer          default(0)
+#  name         :string
+#  sort_order   :integer
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
 require "test_helper"
 
 class RoomSetTest < ActiveSupport::TestCase

--- a/test/models/session_area_test.rb
+++ b/test/models/session_area_test.rb
@@ -1,3 +1,19 @@
+# == Schema Information
+#
+# Table name: session_areas
+#
+#  id           :uuid             not null, primary key
+#  lock_version :integer
+#  primary      :boolean
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  area_id      :uuid
+#  session_id   :uuid
+#
+# Indexes
+#
+#  index_session_areas_on_session_id_and_area_id  (session_id,area_id) UNIQUE
+#
 require 'test_helper'
 
 class SessionAreaTest < ActiveSupport::TestCase

--- a/test/models/session_limit_test.rb
+++ b/test/models/session_limit_test.rb
@@ -1,3 +1,20 @@
+# == Schema Information
+#
+# Table name: session_limits
+#
+#  id           :uuid             not null, primary key
+#  day          :date
+#  lock_version :integer
+#  max_sessions :integer
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  person_id    :uuid
+#
+# Indexes
+#
+#  index_session_limits_on_person_id          (person_id)
+#  index_session_limits_on_person_id_and_day  (person_id,day) UNIQUE
+#
 require "test_helper"
 
 class SessionLimitTest < ActiveSupport::TestCase

--- a/test/models/survey/submission_test.rb
+++ b/test/models/survey/submission_test.rb
@@ -1,3 +1,27 @@
+# == Schema Information
+#
+# Table name: survey_submissions
+#
+#  id               :uuid             not null, primary key
+#  lock_version     :integer          default(0)
+#  name             :string
+#  submission_state :enum             default("draft")
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  person_id        :uuid             not null
+#  survey_id        :uuid             not null
+#
+# Indexes
+#
+#  index_survey_submissions_on_person_id         (person_id)
+#  index_survey_submissions_on_submission_state  (submission_state)
+#  index_survey_submissions_on_survey_id         (survey_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (person_id => people.id)
+#  fk_rails_...  (survey_id => surveys.id)
+#
 require 'test_helper'
 
 class Survey::SubmissionTest < ActiveSupport::TestCase


### PR DESCRIPTION
This adds the [ruby annotate gem](https://github.com/ctran/annotate_models) to the project and populates model annotations on all model+serializer+fixture files. Going forward, `bin/rails migrate` will automatically update the annotations with any model changes. 

The vast majority of the changes here are adding the annotations, the files outside of that are `Gemfile`, `Gemfile.lock`, `Taskfile.yaml` (fixing up the dependencies for `task migrate-dev`), and `lib/tasks/auto_annotate_models.rake`, which is a generated rake task created by `rails g annotations:install`, and is what enables the auto-annotation on migration.