### PR TITLE
PLAN-953 Fix multiple load of surveys for person_surveys

### DIFF
--- a/app/javascript/profile/person_surveys.vue
+++ b/app/javascript/profile/person_surveys.vue
@@ -41,19 +41,16 @@ export default {
   }),
   watch: {
     person: {
-      handler(person) {
-        if(person?.id) {
+      handler(newVal, oldVal) {
+        if(newVal?.id && (newVal?.id != oldVal?.id)) {
+          console.debug("Get surveys for ", newVal.id)
           this.loading = true;
-          this.getPersonSurveys({person}).then(data => {
+          
+          this.getPersonSurveys({person: newVal}).then(data => {
             const {_jv, ...surveys} = data;
             this.surveys = Object.values(data).map(s => ({name: s.name, id: s.id}))
             this.loading = false;
           })
-          // this.getSurveysForPerson(newVal).then(data => {
-          //   // I expect this to come back in [{name: "foo", id: "abc123"}]
-          //   this.surveys = data;
-          //   this.loading = false;
-          // })
         }
       },
       immediate: true


### PR DESCRIPTION
Problem is that the person changes in the store
when the related surveys are fetched. Which
re-triggers the watch on person and so on