### PR TITLE
PLAN-994 Be consistent with timezone

### DIFF
--- a/app/javascript/sessions/datetime_picker.vue
+++ b/app/javascript/sessions/datetime_picker.vue
@@ -58,7 +58,7 @@ export default {
       let retDate = this.value ? DateTime.fromISO(this.value).setZone(this.conventionTimezone) : DateTime.fromISO(this.conventionStart).setZone(this.conventionTimezone);
       if (newTime) {
         console.log('val', newTime, DateTime.fromFormat(newTime, 'HH:mm:ss'))
-        let time = DateTime.fromFormat(newTime, 'HH:mm:ss', {zone: this.conventionTimezone}).toUTC();
+        let time = DateTime.fromFormat(newTime, 'HH:mm:ss', {zone: this.conventionTimezone});
         retDate = retDate.set({
           hour: time.hour,
           minute: time.minute,


### PR DESCRIPTION
Fixes a problem where we are in con TZ in the editor and we munge the
time as if it is UTC and end up off by the hour difference