### PR TITLE
Plan 983 snapshot and gate for conclar

### DIFF
--- a/app/controllers/schedule_controller.rb
+++ b/app/controllers/schedule_controller.rb
@@ -13,33 +13,22 @@ class ScheduleController < ApplicationController
   # 2. If staging or dev use published - if no published then use the live for testing
   # 3. cache mechanism (cache can be popultaed as part of the publish)
   def index
-    cached = PublicationDate.order('created_at desc').first&.publish_snapshots&.schedules&.first
+    cached = PublicationDate.where(sent_external: true).order('created_at desc').first&.publish_snapshots&.schedules&.first
 
     if cached
       render json: cached.snapshot, content_type: 'application/json'
     else
-      sessions = SessionService.scheduled_sessions
-      render json: ActiveModel::Serializer::CollectionSerializer.new(
-                sessions,
-                serializer: Conclar::SessionSerializer
-              ),
-              content_type: 'application/json'
+      render json: [], content_type: 'application/json'
     end
   end
 
   def participants
-    cached = PublicationDate.order('created_at desc').first&.publish_snapshots&.participants&.first
+    cached = PublicationDate.where(sent_external: true).order('created_at desc').first&.publish_snapshots&.participants&.first
 
     if cached
       render json: cached.snapshot, content_type: 'application/json'
     else
-      participants = SessionService.scheduled_people
-
-      render json: ActiveModel::Serializer::CollectionSerializer.new(
-                participants,
-                serializer: Conclar::ParticipantSerializer
-              ),
-              content_type: 'application/json'
+      render json: [], content_type: 'application/json'
     end
   end
 

--- a/app/controllers/schedule_controller.rb
+++ b/app/controllers/schedule_controller.rb
@@ -28,13 +28,19 @@ class ScheduleController < ApplicationController
   end
 
   def participants
-    participants = SessionService.scheduled_people
+    cached = PublicationDate.order('created_at desc').first&.publish_snapshots&.participants&.first
 
-    render json: ActiveModel::Serializer::CollectionSerializer.new(
-              participants,
-              serializer: Conclar::ParticipantSerializer
-            ),
-            content_type: 'application/json'
+    if cached
+      render json: cached.snapshot, content_type: 'application/json'
+    else
+      participants = SessionService.scheduled_people
+
+      render json: ActiveModel::Serializer::CollectionSerializer.new(
+                participants,
+                serializer: Conclar::ParticipantSerializer
+              ),
+              content_type: 'application/json'
+    end
   end
 
   def setup_cache_header

--- a/app/workers/publication_worker.rb
+++ b/app/workers/publication_worker.rb
@@ -30,7 +30,7 @@ class PublicationWorker
     if pub_date
       PublishedSession.transaction do
         SessionService.cache_published_sessions(publication_date: pub_date)
-        # SessionService.cache_published_participants(publication_date: pub_date)
+        SessionService.cache_published_participants(publication_date: pub_date)
       end
     end
   end


### PR DESCRIPTION
Using the sent external for the gatekeeping flag. The latest sent external publish
will be the one that ConClar gets