### PR TITLE
PLAN-785 Put the button back in the UI

### DIFF
--- a/app/javascript/people/people_admin_tab.vue
+++ b/app/javascript/people/people_admin_tab.vue
@@ -24,7 +24,7 @@
             ></icon-button>
           </template>
         </dl-person>
-        <!-- <b-button @click="resyncPerson" variant="primary" :disabled="selected.reg_id == null">Resync Registration</b-button>             -->
+        <b-button @click="resyncPerson" variant="primary" :disabled="selected.reg_id == null">Resync Registration</b-button>
       </div>
       <div class="col-12 col-sm-6 col-lg-4">
         <dt>Status</dt>


### PR DESCRIPTION
The resync works. It does not depend on OAuth. It uses the OAuth identity if it is there or the reg_id for the person. Since the OAuth id is not there it uses the reg id for the person.

Resync only works if the person has a reg_id i.e. they were already associated with a registration.

```
identity = person.oauth_identities.where(provider: 'clyde').first

reg_id = person.reg_id || identity&.reg_id

```
However the button was commented out so I put it back in. Tested it and I saw the new data come back from Clyde.