### PR TITLE
Improve layout on smaller screens

### DIFF
--- a/app/javascript/stylesheets/style.scss
+++ b/app/javascript/stylesheets/style.scss
@@ -22,7 +22,6 @@ dt {
 }
 
 .navbar.navbar-light {
-  height: 100px;
   background: linear-gradient(to right, #ffffff, $color-primary-4 67%);
   border-bottom: 5px solid $color-primary-0;
   .navbar-brand {
@@ -32,6 +31,9 @@ dt {
   }
   &.not-production {
     background: linear-gradient(to right, #ffffff, #f311d8 67%); 
+  }
+  @media (min-width: 576px) {
+    height: 100px;
   }
 }
 

--- a/app/javascript/stylesheets/style.scss
+++ b/app/javascript/stylesheets/style.scss
@@ -37,11 +37,13 @@ dt {
 
 #side-navbar .nav {
   background: $color-light-blue;
-  height: calc(100vh - 150px);
   overflow-y: auto;
   .nav-link.active {
     background: $color-primary-2;
     color: white;
+  }
+  @media (min-width: 576px) {
+    height: calc(100vh - 150px);
   }
 }
 


### PR DESCRIPTION
Bootstrap has a breakpoint at 576px. On screens smaller than 576px
columns are switched to be rows, so that they are laid out vertically
rather than horizontally.

Because `#side-navbar .nav` was always calculating it's hight as 100vh -
footer, regardless of the breakpoint, when the bootstrap layout switch
to a columnular view, the nav bar was taking up the whole screen, and
the tab content was pushed below it. That made it look broken, and like
the tabs hadn't loaded at all. This has led to several people thinking
the state of planorama on mobile is even worse than it actually is.

This patch changes to only calculate the height if we are wider than the
576px breakpoint. If we are not, and hence in the columnular view, we
just let the height be calculated from the nav content, meaning we no
longer push the tag content down off screen.

The header has a fixed height of 100px. This meant that, as the content
wrapped on small screens, the content was bleeding outside of the header
element to under the navigation. Because the navigation is over the top,
you then can't click the logout button.

I'm not sure why the fixed height is needed. But, just in case there is
a good reason for it in the larger screen sizes, I have made a
conservative revision and only remove the height on smaller screen
sizes.

Technically we could switch at a smaller screen size, but the 576px
width is used by bootstrap as a breakpoint, and is close enough to the
actual value that it seems to make sense to use it here.

There is still a lot of work to do to make the UI fully functional on
small screens, but this at least makes it so it doesn't appear to be
completely unusable.