### PR TITLE
Fix timezone for start and end day

### DIFF
--- a/app/javascript/shared/convention-timezone.mixin.js
+++ b/app/javascript/shared/convention-timezone.mixin.js
@@ -9,13 +9,18 @@ export const conventionTimezoneMixin = {
     conventionTimezone() {
       return this.currentSettings?.configs?.find(c => c.parameter === 'convention_timezone')?.parameter_value || 'UTC'
     },
+    /*
+    NOTE: both the start and end days needs to be in the convention timezone. Otherwise if the users
+    computer's timezone is sufficiently different than the cons (like 8 or more hours) the days will
+    be off by one.
+    */
     conventionStart() {
       const val = this.currentSettings?.configs?.find(c => c.parameter === 'convention_start_time')?.parameter_value;
-      return val ? DateTime.fromISO(val) : DateTime.now();
+      return val ? DateTime.fromISO(val).setZone(this.conventionTimezone) : DateTime.now();
     },
     conventionEnd() {
       const val = this.currentSettings?.configs?.find(c => c.parameter === 'convention_end_time')?.parameter_value;
-      return val ? DateTime.fromISO(val) : DateTime.now();
+      return val ? DateTime.fromISO(val).setZone(this.conventionTimezone) : DateTime.now();
     },
     daysArray() {
       let numDays = Math.ceil(this.conventionEnd.diff(this.conventionStart).as('days'));


### PR DESCRIPTION
both the start and end days needs to be in the convention timezone. Otherwise if the users computer's timezone is sufficiently different than the cons (like 8 or more hours) the days will be off by one.