### PR TITLE
PLAN-1044 Fetch does not use the filter, fetchAll does.

### DIFF
--- a/app/javascript/schedule/schedule_calendar.vue
+++ b/app/javascript/schedule/schedule_calendar.vue
@@ -67,7 +67,7 @@ export default {
     },
     init: function() {
       this.loading = true
-      this.fetch({}).then(
+      this.fetchAll({}).then(
         () => {
           // $nextTick ensures that the DOM is rendered... which is usefull
           // when we want to do DOM type functions...


### PR DESCRIPTION
We are supposed to filter to sessions that are scheduled, but apparently the filter was
not applied so we got all of them. So more data is downloaded than needed + the UI does
more work processing data that is not going to be put on the calendars.