### PR TITLE
Change the .env file so that it doesn't conflict with direnv

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,5 @@
 .git*
-.envrc
+.env
 .DS_Store
 .storybook
 db/*.sqlite3

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ capybara-*.html
 .docker-sync
 .yardoc
 .gitlab
-.envrc
+.env
 */db/*.sqlite3
 */public/system
 */coverage/

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Vue.js
 Apart from GIT and whatever IDE/editor you prefer to use the minimum to
 run a dev env is docker desktop.
 
-You will need to create a `.envrc` file. The minimal contant should have
+You will need to create a `.env` file. The minimal contant should have
 
 ```
 export POSTGRES_USER=yourdbuser

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -42,7 +42,7 @@ tasks:
   psql:
     desc: gives you a psql shell against the running dev database
     dotenv:
-      - '.envrc'
+      - '.env'
     cmds:
       - docker-compose -f docker-compose-dev.yml exec postgres psql -U $POSTGRES_USER -d planorama_development
   rails-console:

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -37,7 +37,7 @@ services:
       context: .
       dockerfile: Dockerfile-dev
     env_file:
-      - .envrc
+      - .env
     environment:
       - DB_HOST=postgres
       - RAILS_ENV=development
@@ -69,7 +69,7 @@ services:
       context: .
       dockerfile: Dockerfile-dev
     env_file:
-      - .envrc
+      - .env
     environment:
       - DB_HOST=postgres
       - RAILS_ENV=development
@@ -98,7 +98,7 @@ services:
     image: postgres:12-alpine
     restart: always
     env_file:
-      - .envrc
+      - .env
     volumes:
       - pgdata:/var/lib/postgresql/data
     ports:

--- a/lib/tasks/docker.rake
+++ b/lib/tasks/docker.rake
@@ -41,12 +41,12 @@ namespace :docker do
     puts "run the following command\ndocker run -it --rm --privileged --pid=host planorama:dev nsenter -t 1 -m -u -n -i -- sh -c 'truncate -s0 /var/lib/docker/containers/*/*-json.log'"
   end
 
-  task :psql => :read_envrc do
+  task :psql => :read_env do
     sh "docker", "exec", "-it", "planorama_postgres_1", "psql", "-U", ENV['POSTGRES_USER'], "-d", "planorama_development"
   end
 
-  task :read_envrc do
-    File.open(Rails.root.join('.envrc')) do |f|
+  task :read_env do
+    File.open(Rails.root.join('.env')) do |f|
       f.readlines.each do |line|
         (key, value) = /\w*=\w*/.match(line).to_s.split('=')
         ENV[key] = value


### PR DESCRIPTION
direnv uses `.envrc` files as configuration, which means that the proposed .envrc file format in the README/task file conflict with a common environment management tool.

This replaces all .envrc references with .env, which a more common form for docker as well as being suported as an environment sideload with direnv